### PR TITLE
Modify Some<T> constructor to throw on null

### DIFF
--- a/src/Eithers/Some{T}.cs
+++ b/src/Eithers/Some{T}.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -35,8 +36,10 @@ public class Some<T> : Maybe<T>
     ///   Initialize a new <see cref="Some{T}"/> using a specified value.
     /// </summary>
     /// <param name="value">The value to wrap.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/>
+    ///   is <see langword="null"/>.</exception>
     internal Some(T value) {
-        Value = value;
+        Value = value ?? throw new ArgumentNullException(nameof(value));
     }
 
     /// <summary>

--- a/tests/Eithers.Tests/Some{T}Tests.cs
+++ b/tests/Eithers.Tests/Some{T}Tests.cs
@@ -70,6 +70,11 @@ public class Constructor_Tests {
         Assert.IsInstanceOfType<Maybe<int>>(some);
         Assert.AreEqual(111, some.Value);
     }
+
+    [TestMethod]
+    public void SomeT_constructor_throws_for_null_value() {
+        Assert.ThrowsException<ArgumentNullException>(() => new Some<string>(null!));
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
- Modify `Some<T>` constructor to throw `ArgumentNullException` when the `value` argument is null.
- Add corresponding unit test.