### PR TITLE
Maint/5 refactor redundant test code to parameterized functions

### DIFF
--- a/tests/Eithers.Tests/MaybeTests.cs
+++ b/tests/Eithers.Tests/MaybeTests.cs
@@ -6,29 +6,66 @@ using static Ainsworth.Eithers.Tests.TestData;
 
 namespace Maybe_Tests;
 
-
 /// <summary>
 ///   Unit tests for <see cref="Maybe.From{T}(T?)"/> methods.
 /// </summary>
 [TestClass]
 public class FromT_Method_Tests {
 
+    #region test implementions
+
+    // Value type versions
+
+    private static void Maybe_FromT_creates_Some_from_value<T>(T value) where T : struct {
+        var maybe = Maybe.From<T>(value);
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<Some<T>>(maybe);
+        var some = (maybe as Some<T>)!;
+        Assert.AreEqual(value, some.Value);
+    }
+
+    private static void Maybe_FromT_creates_Some_from_nullable_value<T>(T? value) where T : struct {
+        var maybe = Maybe.From<T>(value);
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<Some<T>>(maybe);
+        var some = (maybe as Some<T>)!;
+        Assert.AreEqual(value, some.Value);
+    }
+
+    private static void Maybe_FromT_creates_None_from_null<T>(T? value) where T : struct {
+        var maybe = Maybe.From<T>(value);
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<None<T>>(maybe);
+        Assert.AreSame(Maybe<T>.None, maybe);
+    }
+
+    // Reference type versions
+
+    private static void Maybe_FromT_creates_Some_from_reference_value<T>(T? value) where T : class {
+        var maybe = Maybe.From<T>(value);
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<Some<T>>(maybe);
+        var some = (maybe as Some<T>)!;
+        Assert.AreEqual(value, some.Value);
+    }
+
+    private static void Maybe_FromT_creates_None_from_null<T>(T? value) where T : class {
+        var maybe = Maybe.From<T>(value);
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<None<T>>(maybe);
+        Assert.AreSame(Maybe<T>.None, maybe);
+    }
+
+    #endregion
+
     /// <summary>
     ///   The <see cref="Maybe.From{T}(T?)"/> method returns a <see cref="Some{T}"/> of the
     ///   correct type wrapping the provided primitive type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_From_creates_correct_type_and_value_for_primitive_types() {
-
-        var enumMaybe = Maybe.From<TestEnum>(TestEnum.E11);
-        Assert.IsInstanceOfType<Maybe<TestEnum>>(enumMaybe);
-        Assert.IsInstanceOfType<Some<TestEnum>>(enumMaybe);
-        Assert.AreEqual(TestEnum.E11, (enumMaybe as Some<TestEnum>)!.Value);
-
-        var intMaybe = Maybe.From<int>(111);
-        Assert.IsInstanceOfType<Maybe<int>>(intMaybe);
-        Assert.IsInstanceOfType<Some<int>>(intMaybe);
-        Assert.AreEqual(111, (intMaybe as Some<int>)!.Value);
+    public void Maybe_FromT_creates_Some_from_primitive_type_value() {
+        Maybe_FromT_creates_Some_from_value(TestEnum.E11);
+        Maybe_FromT_creates_Some_from_value(111);
     }
 
     /// <summary>
@@ -36,19 +73,9 @@ public class FromT_Method_Tests {
     ///   correct wrapping the provided nullable primitive type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_From_creates_correct_type_and_value_for_nullable_primitive_types() {
-
-        TestEnum? nullableEnum = TestEnum.E11;
-        var enumMaybe = (Maybe<TestEnum>)nullableEnum;
-        Assert.IsInstanceOfType<Maybe<TestEnum>>(enumMaybe);
-        Assert.IsInstanceOfType<Some<TestEnum>>(enumMaybe);
-        Assert.AreEqual(TestEnum.E11, (enumMaybe as Some<TestEnum>)!.Value);
-
-        int? nullableInt = 111;
-        var intMaybe = (Maybe<int>)nullableInt;
-        Assert.IsInstanceOfType<Maybe<int>>(intMaybe);
-        Assert.IsInstanceOfType<Some<int>>(intMaybe);
-        Assert.AreEqual(111, (intMaybe as Some<int>)!.Value);
+    public void Maybe_FromT_creates_Some_from_nullable_primitive_type_value() {
+        Maybe_FromT_creates_Some_from_nullable_value((TestEnum?)TestEnum.E11);
+        Maybe_FromT_creates_Some_from_nullable_value((int?)100);
     }
 
     /// <summary>
@@ -56,17 +83,9 @@ public class FromT_Method_Tests {
     ///   correct wrapping the provided value type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_From_creates_correct_type_and_value_for_value_types() {
-
-        var tupleMaybe = Maybe.From<(int, string)>(tupleValue);
-        Assert.IsInstanceOfType<Maybe<(int, string)>>(tupleMaybe);
-        Assert.IsInstanceOfType<Some<(int, string)>>(tupleMaybe);
-        Assert.AreEqual(tupleValue, (tupleMaybe as Some<(int, string)>)!.Value);
-
-        var structMaybe = Maybe.From<Decimal>(111);
-        Assert.IsInstanceOfType<Maybe<Decimal>>(structMaybe);
-        Assert.IsInstanceOfType<Some<Decimal>>(structMaybe);
-        Assert.AreEqual(111, (structMaybe as Some<Decimal>)!.Value);
+    public void Maybe_FromT_creates_Some_from_value_type_value() {
+        Maybe_FromT_creates_Some_from_value((111, "111"));
+        Maybe_FromT_creates_Some_from_value((decimal)111);
     }
 
     /// <summary>
@@ -74,19 +93,9 @@ public class FromT_Method_Tests {
     ///   correct wrapping the provided nullable value type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_From_creates_correct_type_and_value_for_nullable_value_types() {
-
-        (int, string)? nullableTuple = tupleValue;
-        var tupleMaybe = (Maybe<(int, string)>)nullableTuple;
-        Assert.IsInstanceOfType<Maybe<(int, string)>>(tupleMaybe);
-        Assert.IsInstanceOfType<Some<(int, string)>>(tupleMaybe);
-        Assert.AreEqual(tupleValue, (tupleMaybe as Some<(int, string)>)!.Value);
-
-        Decimal? nullableStruct = 111;
-        var structMaybe = (Maybe<Decimal>)nullableStruct;
-        Assert.IsInstanceOfType<Maybe<Decimal>>(structMaybe);
-        Assert.IsInstanceOfType<Some<Decimal>>(structMaybe);
-        Assert.AreEqual(111, (structMaybe as Some<Decimal>)!.Value);
+    public void Maybe_FromT_creates_Some_from_nullable_value_type_value() {
+        Maybe_FromT_creates_Some_from_nullable_value(((int, string)?)(111, "111"));
+        Maybe_FromT_creates_Some_from_nullable_value((decimal?)111);
     }
 
     /// <summary>
@@ -94,22 +103,10 @@ public class FromT_Method_Tests {
     ///   correct wrapping the provided reference type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_From_creates_correct_type_and_value_for_reference_types() {
-
-        var stringMaybe = Maybe.From("111");
-        Assert.IsInstanceOfType<Maybe<string>>(stringMaybe);
-        Assert.IsInstanceOfType<Some<string>>(stringMaybe);
-        Assert.AreEqual("111", (stringMaybe as Some<string>)!.Value);
-
-        var arrayMaybe = Maybe.From(arrayValue);
-        Assert.IsInstanceOfType<Maybe<int[]>>(arrayMaybe);
-        Assert.IsInstanceOfType<Some<int[]>>(arrayMaybe);
-        Assert.AreEqual(arrayValue, (arrayMaybe as Some<int[]>)!.Value);
-
-        var classMaybe = Maybe.From(classValue);
-        Assert.IsInstanceOfType<Maybe<TestClass>>(classMaybe);
-        Assert.IsInstanceOfType<Some<TestClass>>(classMaybe);
-        Assert.AreEqual(classValue, (classMaybe as Some<TestClass>)!.Value);
+    public void Maybe_FromT_creates_Some_from_reference_type_value() {
+        Maybe_FromT_creates_Some_from_reference_value("111");
+        Maybe_FromT_creates_Some_from_reference_value(new int[] { 111 });
+        Maybe_FromT_creates_Some_from_reference_value(new TestClass(111, "111"));
     }
 
     /// <summary>
@@ -117,14 +114,9 @@ public class FromT_Method_Tests {
     ///   <see cref="Maybe{T}.None"/> for nullable primitive type null value.
     /// </summary>
     [TestMethod]
-    public void Maybe_From_creates_correct_type_and_value_for_null_primitive_types() {
-        TestEnum? nullableEnum = null;
-        var enumMaybe = Maybe.From(nullableEnum);
-        Assert.AreSame(Maybe<TestEnum>.None, enumMaybe);
-
-        int? nullableInt = null;
-        var intMaybe = Maybe.From(nullableInt);
-        Assert.AreSame(Maybe<int>.None, intMaybe);
+    public void Maybe_FromT_creates_None_from_primitive_type_null() {
+        Maybe_FromT_creates_None_from_null((TestEnum?)null);
+        Maybe_FromT_creates_None_from_null((int?)null);
     }
 
     /// <summary>
@@ -132,14 +124,9 @@ public class FromT_Method_Tests {
     ///   <see cref="Maybe{T}.None"/> for for nullable primitive type null value.
     /// </summary>
     [TestMethod]
-    public void Maybe_From_creates_correct_type_and_value_for_null_value_yypes() {
-        (int, string)? nullableTuple = null;
-        var tupleMaybe = Maybe.From(nullableTuple);
-        Assert.AreSame(Maybe<(int, string)>.None, tupleMaybe);
-
-        Decimal? nullableStruct = null;
-        var structMaybe = Maybe.From(nullableStruct);
-        Assert.AreSame(Maybe<Decimal>.None, structMaybe);
+    public void Maybe_FromT_creates_None_from_value_type_null() {
+        Maybe_FromT_creates_None_from_null(((int, string)?)null);
+        Maybe_FromT_creates_None_from_null((decimal?)null);
     }
 
     /// <summary>
@@ -147,20 +134,11 @@ public class FromT_Method_Tests {
     ///   <see cref="Maybe{T}.None"/> for for nullable primitive type null value.
     /// </summary>
     [TestMethod]
-    public void Maybe_From_ReturnsNoneInstance_ForNullReferenceTypes() {
-        string? stringValue = null;
-        var stringMaybe = Maybe.From(stringValue);
-        Assert.AreSame(Maybe<string>.None, stringMaybe);
-
-        int[]? arrayValue = null;
-        var arrayMaybe = Maybe.From(arrayValue);
-        Assert.AreSame(Maybe<int[]>.None, arrayMaybe);
-
-        TestClass? classValue = null;
-        var classMaybe = Maybe.From(classValue);
-        Assert.AreSame(Maybe<TestClass>.None, classMaybe);
+    public void Maybe_FromT_creates_None_from_reference_type_null() {
+        Maybe_FromT_creates_None_from_null((string)null!);
+        Maybe_FromT_creates_None_from_null((int[])null!);
+        Maybe_FromT_creates_None_from_null((TestClass?)null!);
     }
-
 }
 
 /// <summary>
@@ -169,22 +147,33 @@ public class FromT_Method_Tests {
 [TestClass]
 public class SomeT_Method_Tests {
 
+    #region test implementions
+
+    // Value type versions
+
+    private static void Maybe_SomeT_creates_Some_from_value<T>(T value) where T : notnull {
+        var maybe = Maybe.Some<T>(value);
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<Some<T>>(maybe);
+        var some = (maybe as Some<T>)!;
+        Assert.AreEqual(value, some.Value);
+    }
+
+    private static void Maybe_SomeT_throws_for_null<T>() where T : class {
+        _ = Assert.ThrowsException<ArgumentNullException>(() => Maybe.Some<T>(null!));
+    }
+
+    #endregion
+
+
     /// <summary>
     ///   The <see cref="Maybe.Some{T}(T)"/> method returns a <see cref="Some{T}"/> of the
     ///   correct type wrapping the provided primitive type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_Some_creates_correct_type_and_value_for_primitive_types() {
-
-        var enumSome = Maybe.Some<TestEnum>(TestEnum.E11);
-        Assert.IsInstanceOfType<Maybe<TestEnum>>(enumSome);
-        Assert.IsInstanceOfType<Some<TestEnum>>(enumSome);
-        Assert.AreEqual(TestEnum.E11, (enumSome as Some<TestEnum>)!.Value);
-
-        var intSome = Maybe.Some<int>(111);
-        Assert.IsInstanceOfType<Maybe<int>>(intSome);
-        Assert.IsInstanceOfType<Some<int>>(intSome);
-        Assert.AreEqual(111, (intSome as Some<int>)!.Value);
+    public void Maybe_SomeT_creates_Some_for_primitive_types() {
+        Maybe_SomeT_creates_Some_from_value(TestEnum.E11);
+        Maybe_SomeT_creates_Some_from_value(111);
     }
 
     /// <summary>
@@ -192,17 +181,9 @@ public class SomeT_Method_Tests {
     ///   correct wrapping the provided value type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_Some_creates_correct_type_and_value_for_value_types() {
-
-        var tupleSome = Maybe.Some<(int, string)>(tupleValue);
-        Assert.IsInstanceOfType<Maybe<(int, string)>>(tupleSome);
-        Assert.IsInstanceOfType<Some<(int, string)>>(tupleSome);
-        Assert.AreEqual(tupleValue, (tupleSome as Some<(int, string)>)!.Value);
-
-        var structSome = Maybe.Some<Decimal>(111);
-        Assert.IsInstanceOfType<Maybe<Decimal>>(structSome);
-        Assert.IsInstanceOfType<Some<Decimal>>(structSome);
-        Assert.AreEqual(111, (structSome as Some<Decimal>)!.Value);
+    public void Maybe_SomeT_creates_Some_for_value_types() {
+        Maybe_SomeT_creates_Some_from_value((111, "111"));
+        Maybe_SomeT_creates_Some_from_value((decimal)111);
     }
 
     /// <summary>
@@ -210,22 +191,10 @@ public class SomeT_Method_Tests {
     ///   correct wrapping the provided reference type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_Some_creates_correct_type_and_value_for_referencetypes() {
-
-        var stringSome = Maybe.Some("111");
-        Assert.IsInstanceOfType<Maybe<string>>(stringSome);
-        Assert.IsInstanceOfType<Some<string>>(stringSome);
-        Assert.AreEqual("111", (stringSome as Some<string>)!.Value);
-
-        var arraySome = Maybe.Some(arrayValue);
-        Assert.IsInstanceOfType<Maybe<int[]>>(arraySome);
-        Assert.IsInstanceOfType<Some<int[]>>(arraySome);
-        Assert.AreEqual(arrayValue, (arraySome as Some<int[]>)!.Value);
-
-        var classSome = Maybe.Some(classValue);
-        Assert.IsInstanceOfType<Maybe<TestClass>>(classSome);
-        Assert.IsInstanceOfType<Some<TestClass>>(classSome);
-        Assert.AreEqual(classValue, (classSome as Some<TestClass>)!.Value);
+    public void Maybe_SomeT_creates_Some_for_referencetypes() {
+        Maybe_SomeT_creates_Some_from_value("111");
+        Maybe_SomeT_creates_Some_from_value(new int[] { 111 });
+        Maybe_SomeT_creates_Some_from_value(new TestClass(111, "111"));
     }
 
     /// <summary>
@@ -234,22 +203,17 @@ public class SomeT_Method_Tests {
     ///   is <see langword="null"/>. 
     /// </summary>
     /// <remarks>
-    ///     <para>This condition will normally be caught by the cC# ompler's null analysis,
+    ///     <para>This condition will normally be caught by the C# ompler's null analysis,
     ///   if nullable analysis is enabled (<c>#nullable endable</c>).  However, analysis
     ///   can not prevent <see cref="Maybe.Some{T}(T)"/> from being called with a
     ///   <see langword="null"/> value.</para>
     ///     <para>*Note*: This cannot happen for primitive and value types.</para>
     /// </remarks>
     [TestMethod]
-    public void Maybe_Some_throws_for_null_reference_types() {
-        string stringValue = null!;
-        _ = Assert.ThrowsException<ArgumentNullException>(() => Maybe.Some(stringValue));
-
-        int[] arrayValue = null!;
-        _ = Assert.ThrowsException<ArgumentNullException>(() => Maybe.Some(arrayValue));
-
-        TestClass classValue = null!;
-        _ = Assert.ThrowsException<ArgumentNullException>(() => Maybe.Some(classValue));
+    public void Maybe_SomeT_throws_for_null_reference_types() {
+        Maybe_SomeT_throws_for_null<string>();
+        Maybe_SomeT_throws_for_null<int[]>();
+        Maybe_SomeT_throws_for_null<TestClass>();
     }
 }
 
@@ -259,24 +223,43 @@ public class SomeT_Method_Tests {
 [TestClass]
 public class ToMaybeT_ExtensionMethod_Tests {
 
+    #region test implementions
+
+    // Value type versions
+
+    private static void Maybe_ToMaybeT_creates_None_from_null<T>(T? value) where T : struct {
+        var maybe = value.ToMaybe();
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<None<T>>(maybe);
+        Assert.AreSame(Maybe<T>.None, maybe);
+    }
+
+    // Reference type versions
+
+    private static void Maybe_ToMaybeT_creates_Some_from_reference_value<T>(T? value) where T : class {
+        var maybe = value.ToMaybe();
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<Some<T>>(maybe);
+        var some = (maybe as Some<T>)!;
+        Assert.AreEqual(value, some.Value);
+    }
+
+    private static void Maybe_ToMaybeT_creates_None_from_null<T>(T? value) where T : class {
+        var maybe = value.ToMaybe();
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<None<T>>(maybe);
+        Assert.AreSame(Maybe<T>.None, maybe);
+    }
+
+    #endregion
+
     /// <summary>
     ///   Ensure the ToMaybe() extension method returns a <see cref="Some{T}"/> of the correct
     ///   type wrapping the provided nullable primitive value.
     /// </summary>
     [TestMethod]
-    public void Maybe_ToMaybe_returns_correct_type_and_value_for_nullable_primitive_yypes() {
-
-        //TestEnum? nullableEnumValue = TestEnum.E11;
-        var enumMaybe = nullableEnumValue.ToMaybe();
-        Assert.IsInstanceOfType<Maybe<TestEnum>>(enumMaybe);
-        Assert.IsInstanceOfType<Some<TestEnum>>(enumMaybe);
-        Assert.AreEqual(TestEnum.E11, (enumMaybe as Some<TestEnum>)!.Value);
-
-        //int? nullableIntValue = 111;
-        var intMaybe = nullableInt111.ToMaybe();
-        Assert.IsInstanceOfType<Maybe<int>>(intMaybe);
-        Assert.IsInstanceOfType<Some<int>>(intMaybe);
-        Assert.AreEqual(111, (intMaybe as Some<int>)!.Value);
+    public void Maybe_ToMaybe_returns_Some_for_nullable_primitive_yypes() {
+        // This is not possible. Use ToSome<T>(T) instead.
     }
 
     /// <summary>
@@ -284,19 +267,8 @@ public class ToMaybeT_ExtensionMethod_Tests {
     ///   type wrapping the provided nullable value type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_ToMaybe_returns_correct_type_and_value_for_nullable_value_types() {
-
-        (int, string)? nullableTupleValue = tupleValue;
-        var tupleMaybe = nullableTupleValue.ToMaybe();
-        Assert.IsInstanceOfType<Maybe<(int, string)>>(tupleMaybe);
-        Assert.IsInstanceOfType<Some<(int, string)>>(tupleMaybe);
-        Assert.AreEqual(tupleValue, (tupleMaybe as Some<(int, string)>)!.Value);
-
-        Decimal? nullableStructValue = 111;
-        var structMaybe = nullableStructValue.ToMaybe();
-        Assert.IsInstanceOfType<Maybe<Decimal>>(structMaybe);
-        Assert.IsInstanceOfType<Some<Decimal>>(structMaybe);
-        Assert.AreEqual(111, (structMaybe as Some<Decimal>)!.Value);
+    public void Maybe_ToMaybe_returns_Some_for_nullable_value_types() {
+        // This is not possible. Use ToSome<T>(T) instead.
     }
 
     /// <summary>
@@ -304,40 +276,74 @@ public class ToMaybeT_ExtensionMethod_Tests {
     ///   type wrapping the provided nullable reference type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_ToMaybe_returns_correct_type_and_value_for_nullable_reference_types() {
-
-        var stringMaybe = "111".ToMaybe();
-        Assert.IsInstanceOfType<Maybe<string>>(stringMaybe);
-        Assert.IsInstanceOfType<Some<string>>(stringMaybe);
-        Assert.AreEqual("111", (stringMaybe as Some<string>)!.Value);
-
-        var arrayMaybe = arrayValue.ToMaybe();
-        Assert.IsInstanceOfType<Maybe<int[]>>(arrayMaybe);
-        Assert.IsInstanceOfType<Some<int[]>>(arrayMaybe);
-        Assert.AreEqual(arrayValue, (arrayMaybe as Some<int[]>)!.Value);
-
-        var classMaybe = classValue.ToMaybe();
-        Assert.IsInstanceOfType<Maybe<TestClass>>(classMaybe);
-        Assert.IsInstanceOfType<Some<TestClass>>(classMaybe);
-        Assert.AreEqual(classValue, (classMaybe as Some<TestClass>)!.Value);
+    public void Maybe_ToMaybe_returns_Some_for_nullable_reference_types() {
+        Maybe_ToMaybeT_creates_Some_from_reference_value<string>("111");
+        Maybe_ToMaybeT_creates_Some_from_reference_value<int[]>(new int[] { 111 });
+        Maybe_ToMaybeT_creates_Some_from_reference_value<TestClass>(new TestClass(111, "111"));
     }
+
+    /// <summary>
+    ///   The <see cref="Maybe.ToMaybe{T}(T?)"/> method returns the correct instance of
+    ///   <see cref="Maybe{T}.None"/> for nullable primitive type null value.
+    /// </summary>
+    [TestMethod]
+    public void Maybe_ToMaybe_creates_None_from_primitive_type_null() {
+        Maybe_ToMaybeT_creates_None_from_null((TestEnum?)null);
+        Maybe_ToMaybeT_creates_None_from_null((int?)null);
+    }
+
+    /// <summary>
+    ///   The <see cref="Maybe.ToMaybe{T}(T?)"/> method returns the correct instance of
+    ///   <see cref="Maybe{T}.None"/> for for nullable primitive type null value.
+    /// </summary>
+    [TestMethod]
+    public void Maybe_ToMaybe_creates_None_from_value_type_null() {
+        Maybe_ToMaybeT_creates_None_from_null(((int, string)?)null);
+        Maybe_ToMaybeT_creates_None_from_null((decimal?)null);
+    }
+
+    /// <summary>
+    ///   The <see cref="Maybe.ToMaybe{T}(T?)"/> method returns the correct instance of
+    ///   <see cref="Maybe{T}.None"/> for for nullable primitive type null value.
+    /// </summary>
+    [TestMethod]
+    public void Maybe_ToMaybe_creates_None_from_reference_type_null() {
+        Maybe_ToMaybeT_creates_None_from_null((string)null!);
+        Maybe_ToMaybeT_creates_None_from_null((int[])null!);
+        Maybe_ToMaybeT_creates_None_from_null((TestClass?)null!);
+    }
+}
+
+/// <summary>
+///   Unit tests for <see cref="Maybe.ToMaybe{T}(T?)"/> extention methods.
+/// </summary>
+[TestClass]
+public class ToSomeT_ExtensionMethod_Tests {
+
+    #region test implementions
+
+    private static void Maybe_ToSomeT_creates_Some_from_value<T>(T value) where T : notnull {
+        var maybe = value.ToSome();
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<Some<T>>(maybe);
+        var some = (maybe as Some<T>)!;
+        Assert.AreEqual(value, some.Value);
+    }
+
+    private static void Maybe_ToSomeT_throws_for_null<T>() where T : class {
+        _ = Assert.ThrowsException<ArgumentNullException>(() => ((T)null!).ToSome());
+    }
+
+    #endregion
 
     /// <summary>
     ///   Ensure the ToSome() extension method returns a <see cref="Some{T}"/> of the correct
     ///   type wrapping the provided nullable primitive value.
     /// </summary>
     [TestMethod]
-    public void Maybe_ToSome_returns_correct_type_and_value_for_primitive_types() {
-
-        var enumSome = TestEnum.E11.ToSome();
-        Assert.IsInstanceOfType<Maybe<TestEnum>>(enumSome);
-        Assert.IsInstanceOfType<Some<TestEnum>>(enumSome);
-        Assert.AreEqual(TestEnum.E11, (enumSome as Some<TestEnum>)!.Value);
-
-        var intSome = 111.ToSome();
-        Assert.IsInstanceOfType<Maybe<int>>(intSome);
-        Assert.IsInstanceOfType<Some<int>>(intSome);
-        Assert.AreEqual(111, (intSome as Some<int>)!.Value);
+    public void Maybe_ToSome_returns_Some_for_primitive_types() {
+        Maybe_ToSomeT_creates_Some_from_value(TestEnum.E11);
+        Maybe_ToSomeT_creates_Some_from_value(111);
     }
 
     /// <summary>
@@ -345,17 +351,9 @@ public class ToMaybeT_ExtensionMethod_Tests {
     ///   type wrapping the provided nullable value type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_ToSome_returns_correct_type_and_value_for_value_types() {
-
-        var tupleSome = tupleValue.ToSome();
-        Assert.IsInstanceOfType<Maybe<(int, string)>>(tupleSome);
-        Assert.IsInstanceOfType<Some<(int, string)>>(tupleSome);
-        Assert.AreEqual(tupleValue, (tupleSome as Some<(int, string)>)!.Value);
-
-        var structSome = ((Decimal)111).ToSome();
-        Assert.IsInstanceOfType<Maybe<Decimal>>(structSome);
-        Assert.IsInstanceOfType<Some<Decimal>>(structSome);
-        Assert.AreEqual(111, (structSome as Some<Decimal>)!.Value);
+    public void Maybe_ToSome_returns_Some_for_value_types() {
+        Maybe_ToSomeT_creates_Some_from_value((111, "111"));
+        Maybe_ToSomeT_creates_Some_from_value((decimal)111);
     }
 
     /// <summary>
@@ -363,21 +361,28 @@ public class ToMaybeT_ExtensionMethod_Tests {
     ///   type wrapping the provided nullable reference type value.
     /// </summary>
     [TestMethod]
-    public void Maybe_ToSome_returns_correct_type_and_value_for_reference_types() {
+    public void Maybe_ToSome_returns_Some_for_reference_types() {
+        Maybe_ToSomeT_creates_Some_from_value<string>("111");
+        Maybe_ToSomeT_creates_Some_from_value(new int[] { 111 });
+        Maybe_ToSomeT_creates_Some_from_value(new TestClass(111, "111"));
+    }
 
-        var stringSome = "111".ToSome();
-        Assert.IsInstanceOfType<Maybe<string>>(stringSome);
-        Assert.IsInstanceOfType<Some<string>>(stringSome);
-        Assert.AreEqual("111", (stringSome as Some<string>)!.Value);
-
-        var arraySome = arrayValue.ToSome();
-        Assert.IsInstanceOfType<Maybe<int[]>>(arraySome);
-        Assert.IsInstanceOfType<Some<int[]>>(arraySome);
-        Assert.AreEqual(arrayValue, (arraySome as Some<int[]>)!.Value);
-
-        var classSome = classValue.ToSome();
-        Assert.IsInstanceOfType<Maybe<TestClass>>(classSome);
-        Assert.IsInstanceOfType<Some<TestClass>>(classSome);
-        Assert.AreEqual(classValue, (classSome as Some<TestClass>)!.Value);
+    /// <summary>
+    ///   The <see cref="Maybe.ToSome{T}(T)"/> method throws an
+    ///   <see cref="ArgumentNullException"/> when a non-nullable reference type value
+    ///   is <see langword="null"/>. 
+    /// </summary>
+    /// <remarks>
+    ///     <para>This condition will normally be caught by the C# ompler's null analysis,
+    ///   if nullable analysis is enabled (<c>#nullable endable</c>).  However, analysis
+    ///   can not prevent <see cref="Maybe.Some{T}(T)"/> from being called with a
+    ///   <see langword="null"/> value.</para>
+    ///     <para>*Note*: This cannot happen for primitive and value types.</para>
+    /// </remarks>
+    [TestMethod]
+    public void Maybe_ToSomeT_throws_for_null_reference_types() {
+        Maybe_ToSomeT_throws_for_null<string>();
+        Maybe_ToSomeT_throws_for_null<int[]>();
+        Maybe_ToSomeT_throws_for_null<TestClass>();
     }
 }

--- a/tests/Eithers.Tests/Maybe{T}Tests.cs
+++ b/tests/Eithers.Tests/Maybe{T}Tests.cs
@@ -12,112 +12,6 @@ namespace MaybeT_Tests;
 ///   Unit tests for <see cref="Maybe{T}"/> casts.
 /// </summary>
 [TestClass]
-public class MaybeT_Cast_Tests {
-
-    /// <summary>
-    ///   The <see cref="Maybe{T}"/> cast returns a <see cref="Some{T}"/> of the 
-    ///   correct wrapping the provided primitive value.
-    /// </summary>
-    [TestMethod]
-    public void MaybeT_cast_creates_correct_type_and_value_for_primitive_types() {
-
-        var enumMaybe = (Maybe<TestEnum>)TestEnum.E11;
-        Assert.IsInstanceOfType<Maybe<TestEnum>>(enumMaybe);
-        Assert.IsInstanceOfType<Some<TestEnum>>(enumMaybe);
-        Assert.AreEqual(TestEnum.E11, (enumMaybe as Some<TestEnum>)!.Value);
-
-        var intMaybe = (Maybe<int>)111;
-        Assert.IsInstanceOfType<Maybe<int>>(intMaybe);
-        Assert.IsInstanceOfType<Some<int>>(intMaybe);
-        Assert.AreEqual(111, (intMaybe as Some<int>)!.Value);
-    }
-
-    /// <summary>
-    ///   The <see cref="Maybe{T}"/> cast returns a <see cref="Some{T}"/> of the 
-    ///   correct wrapping the provided nullable value type value.
-    /// </summary>
-    [TestMethod]
-    public void MaybeT_cast_creates_correct_type_and_value_for_nullable_primitive_types() {
-
-        TestEnum? nullableEnum = TestEnum.E11;
-        var enumMaybe = (Maybe<TestEnum>)nullableEnum;
-        Assert.IsInstanceOfType<Maybe<TestEnum>>(enumMaybe);
-        Assert.IsInstanceOfType<Some<TestEnum>>(enumMaybe);
-        Assert.AreEqual(TestEnum.E11, (enumMaybe as Some<TestEnum>)!.Value);
-
-        int? nullableInt = 111;
-        var intMaybe = (Maybe<int>)nullableInt;
-        Assert.IsInstanceOfType<Maybe<int>>(intMaybe);
-        Assert.IsInstanceOfType<Some<int>>(intMaybe);
-        Assert.AreEqual(111, (intMaybe as Some<int>)!.Value);
-    }
-
-    /// <summary>
-    ///   The <see cref="Maybe{T}"/> cast returns a <see cref="Some{T}"/> of the 
-    ///   correct wrapping the provided value type value.
-    /// </summary>
-    [TestMethod]
-    public void MaybeT_Cast_creates_correct_type_and_value_for_value_types() {
-
-        var tupleMaybe = (Maybe<(int, string)>)tupleValue;
-        Assert.IsInstanceOfType<Maybe<(int, string)>>(tupleMaybe);
-        Assert.IsInstanceOfType<Some<(int, string)>>(tupleMaybe);
-        Assert.AreEqual(tupleValue, (tupleMaybe as Some<(int, string)>)!.Value);
-
-        var structMaybe = (Maybe<Decimal>)111;
-        Assert.IsInstanceOfType<Maybe<Decimal>>(structMaybe);
-        Assert.IsInstanceOfType<Some<Decimal>>(structMaybe);
-        Assert.AreEqual(111, (structMaybe as Some<Decimal>)!.Value);
-    }
-
-    /// <summary>
-    ///   The <see cref="Maybe{T}"/> cast returns a <see cref="Some{T}"/> of the 
-    ///   correct wrapping the provided nullable value type value.
-    /// </summary>
-    [TestMethod]
-    public void MaybeT_cast_creates_correct_type_and_value_for_nullable_value_types() {
-
-        (int, string)? nullableTuple = tupleValue;
-        var tupleMaybe = (Maybe<(int, string)>)nullableTuple;
-        Assert.IsInstanceOfType<Maybe<(int, string)>>(tupleMaybe);
-        Assert.IsInstanceOfType<Some<(int, string)>>(tupleMaybe);
-        Assert.AreEqual(tupleValue, (tupleMaybe as Some<(int, string)>)!.Value);
-
-        Decimal? nullableStruct = 111;
-        var structMaybe = (Maybe<Decimal>)nullableStruct;
-        Assert.IsInstanceOfType<Maybe<Decimal>>(structMaybe);
-        Assert.IsInstanceOfType<Some<Decimal>>(structMaybe);
-        Assert.AreEqual(111, (structMaybe as Some<Decimal>)!.Value);
-    }
-
-    /// <summary>
-    ///   The <see cref="Maybe{T}"/> cast returns a <see cref="Some{T}"/> of the 
-    ///   correct wrapping the provided nullable reference type value.
-    /// </summary>
-    [TestMethod]
-    public void MaybeT_cast_creates_correct_type_and_value_for_reference_types() {
-
-        var stringMaybe = (Maybe<string>)"111";
-        Assert.IsInstanceOfType<Maybe<string>>(stringMaybe);
-        Assert.IsInstanceOfType<Some<string>>(stringMaybe);
-        Assert.AreEqual("111", (stringMaybe as Some<string>)!.Value);
-
-        var arrayMaybe = (Maybe<int[]>)arrayValue;
-        Assert.IsInstanceOfType<Maybe<int[]>>(arrayMaybe);
-        Assert.IsInstanceOfType<Some<int[]>>(arrayMaybe);
-        Assert.AreEqual(arrayValue, (arrayMaybe as Some<int[]>)!.Value);
-
-        var classMaybe = (Maybe<TestClass>)classValue;
-        Assert.IsInstanceOfType<Maybe<TestClass>>(classMaybe);
-        Assert.IsInstanceOfType<Some<TestClass>>(classMaybe);
-        Assert.AreEqual(classValue, (classMaybe as Some<TestClass>)!.Value);
-    }
-}
-
-/// <summary>
-///   Unit tests for <see cref="Maybe{T}"/> casts.
-/// </summary>
-[TestClass]
 public class Constructor_Tests {
 
     /// <summary>
@@ -161,16 +55,46 @@ public class EqualsMaybeT_Method_Tests {
 [TestClass]
 public class EqualsObject_Method_Tests {
 
+    #region test implementions
+
+    private static void MaybeT_EqualsObject_returns_true_if_same_value<T>(T value)
+            where T : notnull {
+        Maybe<T> maybe = new Some<T>(value);
+        Assert.IsTrue(maybe.Equals((object)value));
+    }
+
+    private static void MaybeT_EqualsObject_returns_false_if_different_value<T>(T value, T value2)
+            where T : notnull {
+        Maybe<T> maybe = new Some<T>(value);
+        Assert.IsFalse(maybe.Equals((object)value2));
+    }
+
+    private static void MaybeT_EqualsObject_returns_false_for_None_and_value<T>(T value2)
+            where T : notnull =>
+        Assert.IsFalse(Maybe<T>.None.Equals((object)value2));
+
+    private static void MaybeT_EqualsObject_returns_false_for_None_and_null<T>()
+            where T : struct =>
+        Assert.IsFalse(Maybe<T>.None.Equals((object)(T?)null!));
+
+    private static void MaybeT_EqualsObject_returns_false_for_None_and_null_reference<T>()
+            where T : class =>
+        Assert.IsFalse(Maybe<T>.None.Equals((object)(T)null!));
+
+    private static void MaybeT_EqualsObject_returns_true_for_None_and_None<T>()
+            where T : notnull =>
+        Assert.IsTrue(Maybe<T>.None.Equals((object)Maybe<T>.None));
+
+    #endregion
+
     /// <summary>
     ///  The <see cref="Some{T}.Equals(T)"/> method returns <see langword="true"/>
     ///  for primitive types with the same values.
     /// </summary>
     [TestMethod]
-    public void MaybeT_with_value_EqualsObject_returns_true_for_primitive_types_with_the_same_value() {
-        Maybe<int> intSome = new Some<int>(111);
-        Assert.IsTrue(intSome.Equals((object)111));
-        Maybe<TestEnum> enumSome = new Some<TestEnum>(TestEnum.E11);
-        Assert.IsTrue(enumSome.Equals((object)TestEnum.E11));
+    public void MaybeT_EqualsObject_returns_true_for_primitive_types_with_the_same_value() {
+        MaybeT_EqualsObject_returns_true_if_same_value(TestEnum.E11);
+        MaybeT_EqualsObject_returns_true_if_same_value(111);
     }
 
     /// <summary>
@@ -178,11 +102,9 @@ public class EqualsObject_Method_Tests {
     ///  for value types with the same values.
     /// </summary>
     [TestMethod]
-    public void MaybeT_with_value_EqualsObject_returns_true_for_value_types_with_the_same_value() {
-        Maybe<(int, string)> tupleSome = new Some<(int, string)>((111, "111"));
-        Assert.IsTrue(tupleSome.Equals((object)(111, "111")));
-        Maybe<Decimal> decimalSome = new Some<Decimal>(111);
-        Assert.IsTrue(decimalSome.Equals((object)(Decimal)111));
+    public void MaybeT_EqualsObject_returns_true_for_value_types_with_the_same_value() {
+        MaybeT_EqualsObject_returns_true_if_same_value((111, "111"));
+        MaybeT_EqualsObject_returns_true_if_same_value((decimal)111);
     }
 
     /// <summary>
@@ -190,21 +112,14 @@ public class EqualsObject_Method_Tests {
     ///  for reference types with the same values.
     /// </summary>
     [TestMethod]
-    public void MaybeT_with_value_EqualsObject_returns_true_for_reference_types_with_the_same_value() {
+    public void MaybeT_EqualsObject_returns_true_for_reference_types_with_the_same_value() {
 
         // Note: string overrides Equals to compare by value.
         // All other reference types compare by reference.
 
-        Maybe<string> stringSome = new Some<string>("111");
-        Assert.IsTrue(stringSome.Equals((object)"111"));
-
-        var arrayValue = new int[] { 111 };
-        Maybe<int[]> arraySome = new Some<int[]>(arrayValue);
-        Assert.IsTrue(arraySome.Equals((object)arrayValue));
-
-        var classValue = new TestClass(111, "111");
-        Maybe<TestClass> classSome = new Some<TestClass>(classValue);
-        Assert.IsTrue(classSome.Equals((object)classValue));
+        MaybeT_EqualsObject_returns_true_if_same_value("111");
+        MaybeT_EqualsObject_returns_true_if_same_value(new int[] { 111 });
+        MaybeT_EqualsObject_returns_true_if_same_value(new TestClass(111, "111"));
     }
 
     /// <summary>
@@ -212,11 +127,9 @@ public class EqualsObject_Method_Tests {
     ///  for primitive types with the same values.
     /// </summary>
     [TestMethod]
-    public void MaybeT_with_value_EqualsObject_returns_false_for_primitive_types_with_the_different_value() {
-        Maybe<int> intSome = new Some<int>(111);
-        Assert.IsFalse(intSome.Equals((object)222));
-        Maybe<TestEnum> enumSome = new Some<TestEnum>(TestEnum.E11);
-        Assert.IsFalse(enumSome.Equals((object)TestEnum.E22));
+    public void MaybeT_EqualsObject_returns_false_for_primitive_types_with_the_different_value() {
+        MaybeT_EqualsObject_returns_false_if_different_value(TestEnum.E11, TestEnum.E22);
+        MaybeT_EqualsObject_returns_false_if_different_value(111, 222);
     }
 
     /// <summary>
@@ -224,11 +137,9 @@ public class EqualsObject_Method_Tests {
     ///  for value types with the same values.
     /// </summary>
     [TestMethod]
-    public void MaybeT_with_value_EqualsObject_returns_false_for_value_types_with_the_different_value() {
-        Maybe<(int, string)> tupleSome = new Some<(int, string)>((111, "111"));
-        Assert.IsFalse(tupleSome.Equals((object)(222, "222")));
-        Maybe<Decimal> decimalSome = new Some<Decimal>(111);
-        Assert.IsFalse(decimalSome.Equals((object)(Decimal)222));
+    public void MaybeT_EqualsObject_returns_false_for_value_types_with_the_different_value() {
+        MaybeT_EqualsObject_returns_false_if_different_value((111, "111"), (222, "222"));
+        MaybeT_EqualsObject_returns_false_if_different_value((decimal)111, (decimal)222);
     }
 
     /// <summary>
@@ -236,21 +147,15 @@ public class EqualsObject_Method_Tests {
     ///  for reference types with the same values.
     /// </summary>
     [TestMethod]
-    public void MaybeT_with_value_EqualsObject_returns_false_for_reference_types_with_the_different_value() {
+    public void MaybeT_EqualsObject_returns_false_for_reference_types_with_the_different_value() {
 
         // Note: string overrides Equals to compare by value.
         // All other reference types compare by reference.
 
-        Maybe<string> stringSome = new Some<string>("111");
-        Assert.IsFalse(stringSome.Equals((object)"222"));
-
-        var arrayValue = new int[] { 111 };
-        Maybe<int[]> arraySome = new Some<int[]>(arrayValue);
-        Assert.IsFalse(arraySome.Equals((object)new int[] { 222 }));
-
-        var classValue = new TestClass(111, "111");
-        Maybe<TestClass> classSome = new Some<TestClass>(classValue);
-        Assert.IsFalse(classSome.Equals((object)new TestClass(222, "222")));
+        MaybeT_EqualsObject_returns_false_if_different_value("111", "222");
+        MaybeT_EqualsObject_returns_false_if_different_value(new int[] { 111 }, new int[] { 222 });
+        MaybeT_EqualsObject_returns_false_if_different_value(
+            new TestClass(111, "111"), new TestClass(222, "222"));
     }
 
     /// <summary>
@@ -259,8 +164,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_primitive_type_values() {
-        Assert.IsFalse(Maybe<TestEnum>.None.Equals((object)TestEnum.E11));
-        Assert.IsFalse(Maybe<int>.None.Equals((object)111));
+        MaybeT_EqualsObject_returns_false_for_None_and_value(TestEnum.E22);
+        MaybeT_EqualsObject_returns_false_for_None_and_value(222);
     }
 
     /// <summary>
@@ -269,8 +174,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_value_types_values() {
-        Assert.IsFalse(Maybe<(int, string)>.None.Equals((object)tupleValue));
-        Assert.IsFalse(Maybe<Decimal>.None.Equals((object)(Decimal)111));
+        MaybeT_EqualsObject_returns_false_for_None_and_value((222, "222"));
+        MaybeT_EqualsObject_returns_false_for_None_and_value((decimal)222);
     }
 
     /// <summary>
@@ -279,9 +184,9 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_reference_types_values() {
-        Assert.IsFalse(Maybe<string>.None.Equals((object)"111"));
-        Assert.IsFalse(Maybe<int[]>.None.Equals((object)arrayValue));
-        Assert.IsFalse(Maybe<TestClass>.None.Equals((object)classValue));
+        MaybeT_EqualsObject_returns_false_for_None_and_value("222");
+        MaybeT_EqualsObject_returns_false_for_None_and_value(new int[] { 222 });
+        MaybeT_EqualsObject_returns_false_for_None_and_value(new TestClass(222, "222"));
     }
 
     /// <summary>
@@ -290,10 +195,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_null_primitive_types() {
-        TestEnum? nullEnum = null;
-        Assert.IsFalse(Maybe<TestEnum>.None.Equals((object?)nullEnum));
-        int? nullInt = null;
-        Assert.IsFalse(Maybe<int>.None.Equals((object?)nullInt));
+        MaybeT_EqualsObject_returns_false_for_None_and_null<TestEnum>();
+        MaybeT_EqualsObject_returns_false_for_None_and_null<int>();
     }
 
     /// <summary>
@@ -302,10 +205,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_null_value_types() {
-        (int, string)? nullTuple = null;
-        Assert.IsFalse(Maybe<(int, string)>.None.Equals((object?)nullTuple));
-        Decimal? nullDecimal = null;
-        Assert.IsFalse(Maybe<Decimal>.None.Equals((object?)nullDecimal));
+        MaybeT_EqualsObject_returns_false_for_None_and_null<(int, string)>();
+        MaybeT_EqualsObject_returns_false_for_None_and_null<decimal>();
     }
 
     /// <summary>
@@ -314,12 +215,9 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_null_reference_types() {
-        string nullString = null!;
-        Assert.IsFalse(Maybe<string>.None.Equals((object)nullString));
-        int[] nullArray = null!;
-        Assert.IsFalse(Maybe<int[]>.None.Equals((object)nullArray));
-        TestClass nullClass = null!;
-        Assert.IsFalse(Maybe<TestClass>.None.Equals((object)nullClass));
+        MaybeT_EqualsObject_returns_false_for_None_and_null_reference<string>();
+        MaybeT_EqualsObject_returns_false_for_None_and_null_reference<int[]>();
+        MaybeT_EqualsObject_returns_false_for_None_and_null_reference<TestClass>();
     }
 
     /// <summary>
@@ -327,9 +225,9 @@ public class EqualsObject_Method_Tests {
     ///  for primitive type <see cref="Maybe{T}.None"/> values.
     /// </summary>
     [TestMethod]
-    public void MaybeT_without_value_EqualsObject_returns_false_for_primitive_type_NoneTs() {
-        Assert.IsTrue(Maybe<TestEnum>.None.Equals((object?)Maybe<TestEnum>.None));
-        Assert.IsTrue(Maybe<int>.None.Equals((object?)Maybe<int>.None));
+    public void MaybeT_without_value_EqualsObject_returns_true_for_primitive_type_None() {
+        MaybeT_EqualsObject_returns_true_for_None_and_None<TestEnum>();
+        MaybeT_EqualsObject_returns_true_for_None_and_None<int>();
     }
 
     /// <summary>
@@ -337,9 +235,9 @@ public class EqualsObject_Method_Tests {
     ///  for value type <see cref="Maybe{T}.None"/> values.
     /// </summary>
     [TestMethod]
-    public void MaybeT_without_value_EqualsObject_returns_false_for_value_type_NoneTs() {
-        Assert.IsTrue(Maybe<(int, string)>.None.Equals((object?)Maybe<(int, string)>.None));
-        Assert.IsTrue(Maybe<Decimal>.None.Equals((object?)Maybe<Decimal>.None));
+    public void MaybeT_without_value_EqualsObject_returns_true_for_value_type_None() {
+        MaybeT_EqualsObject_returns_true_for_None_and_None<(int, string)>();
+        MaybeT_EqualsObject_returns_true_for_None_and_None<decimal>();
     }
 
     /// <summary>
@@ -347,10 +245,10 @@ public class EqualsObject_Method_Tests {
     ///  for reference type <see cref="Maybe{T}.None"/> values.
     /// </summary>
     [TestMethod]
-    public void MaybeT_without_value_EqualsObject_returns_false_for_reference_type_NoneTs() {
-        Assert.IsTrue(Maybe<string>.None.Equals((object)Maybe<string>.None));
-        Assert.IsTrue(Maybe<int[]>.None.Equals((object)Maybe<int[]>.None));
-        Assert.IsTrue(Maybe<TestClass>.None.Equals((object)Maybe<TestClass>.None));
+    public void MaybeT_without_value_EqualsObject_returns_true_for_reference_type_None() {
+        MaybeT_EqualsObject_returns_true_for_None_and_None<string>();
+        MaybeT_EqualsObject_returns_true_for_None_and_None<int[]>();
+        MaybeT_EqualsObject_returns_true_for_None_and_None<TestClass>();
     }
 }
 
@@ -421,20 +319,25 @@ public class GetEnumerator_Method_Tests {
 [TestClass]
 public class GetHashCode_Method_Tests {
 
+    #region test implementaions
+
+    private static void MaybeT_GetHashCode_returns_correct_value<T>(T value, T value2)
+            where T: notnull {
+        var maybe = Maybe.Some<T>(value);
+        Assert.AreEqual(value.GetHashCode(), maybe.GetHashCode());
+        Assert.AreNotEqual(value2.GetHashCode(), maybe.GetHashCode());
+    }
+
+    #endregion
+
     /// <summary>
     ///   The <see cref="Maybe{T}.GetHashCode"/> method returns the correct value
     ///   for primitive type values.
     /// </summary>
     [TestMethod]
     public void MaybeT_GetHashCode_returns_correct_value_for_primitive_types() {
-
-        var enumMaybe = Maybe.From<TestEnum>(TestEnum.E11);
-        Assert.AreEqual(TestEnum.E11.GetHashCode(), enumMaybe.GetHashCode());
-        Assert.AreNotEqual(TestEnum.E22.GetHashCode(), enumMaybe.GetHashCode());
-
-        var intMaybe = Maybe.From<int>(111);
-        Assert.AreEqual(111.GetHashCode(), intMaybe.GetHashCode());
-        Assert.AreNotEqual(222.GetHashCode(), intMaybe.GetHashCode());
+        MaybeT_GetHashCode_returns_correct_value(TestEnum.E11, TestEnum.E22);
+        MaybeT_GetHashCode_returns_correct_value(111, 222);
     }
 
     /// <summary>
@@ -443,14 +346,8 @@ public class GetHashCode_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_GetHashCode_returns_correct_value_for_value_types() {
-
-        var tupleMaybe = Maybe.From<(int, string)>(tupleValue);
-        Assert.AreEqual(tupleValue.GetHashCode(), tupleMaybe.GetHashCode());
-        Assert.AreNotEqual(tupleValue2.GetHashCode(), tupleMaybe.GetHashCode());
-
-        var structMaybe = Maybe.From<Decimal>(111);
-        Assert.AreEqual(((Decimal)111).GetHashCode(), structMaybe.GetHashCode());
-        Assert.AreNotEqual(((Decimal)222).GetHashCode(), structMaybe.GetHashCode());
+        MaybeT_GetHashCode_returns_correct_value((111, "111"), (222, "222"));
+        MaybeT_GetHashCode_returns_correct_value((decimal)111, (decimal)222);
     }
 
     /// <summary>
@@ -462,18 +359,10 @@ public class GetHashCode_Method_Tests {
         "Globalization", "CA1307:Specify StringComparison for clarity",
         Justification = "StringComparison cannot be used within Maybe<T>")]
     public void MaybeT_GetHashCode_returns_correct_value_for_reference_types() {
-
-        var stringMaybe = Maybe.From("111");
-        Assert.AreEqual("111".GetHashCode(), stringMaybe.GetHashCode());
-        Assert.AreNotEqual("222".GetHashCode(), stringMaybe.GetHashCode());
-
-        var arrayMaybe = Maybe.From(arrayValue);
-        Assert.AreEqual(arrayValue.GetHashCode(), arrayMaybe.GetHashCode());
-        Assert.AreNotEqual(arrayValue2.GetHashCode(), arrayMaybe.GetHashCode());
-
-        var classMaybe = Maybe.From(classValue);
-        Assert.AreEqual(classValue.GetHashCode(), classMaybe.GetHashCode());
-        Assert.AreNotEqual(classValue2.GetHashCode(), classMaybe.GetHashCode());
+        MaybeT_GetHashCode_returns_correct_value("111", "222");
+        MaybeT_GetHashCode_returns_correct_value(new int[] { 111 }, new int[] { 222 });
+        MaybeT_GetHashCode_returns_correct_value(
+            new TestClass(111, "111"), new TestClass(222, "222"));
     }
 }
 
@@ -505,5 +394,136 @@ public class HasValue_Property_Tests {
         var nullIntMaybe = Maybe.From<int>(nullInt);
         Assert.IsInstanceOfType<Maybe<int>>(nullIntMaybe);
         Assert.IsFalse(nullIntMaybe.HasValue);
+    }
+}
+
+/// <summary>
+///   Unit tests for <see cref="Maybe{T}"/> casts.
+/// </summary>
+[TestClass]
+public class MaybeT_Cast_Tests {
+
+    #region test implementions
+
+    private static void MaybeT_cast_creates_Some_from_value<T>(T value) where T : struct {
+        var maybe = (Maybe<T>)value;
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<Some<T>>(maybe);
+        var some = (maybe as Some<T>)!;
+        Assert.AreEqual(value, some.Value);
+    }
+
+    private static void MaybeT_cast_creates_Some_from_nullable_value<T>(T value) where T : struct {
+        var maybe = (Maybe<T>)(T?)value;
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<Some<T>>(maybe);
+        var some = (maybe as Some<T>)!;
+        Assert.AreEqual(value, some.Value);
+    }
+
+    private static void MaybeT_cast_creates_None_from_null<T>(T? value) where T : struct {
+        var maybe = Maybe.From<T>(value);
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<None<T>>(maybe);
+        Assert.AreSame(Maybe<T>.None, maybe);
+    }
+
+    private static void MaybeT_cast_creates_Some_from_reference_value<T>(T value) where T : class {
+        var maybe = Maybe.From<T>(value);
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<Some<T>>(maybe);
+        var some = (maybe as Some<T>)!;
+        Assert.AreEqual(value, some.Value);
+    }
+
+    private static void MaybeT_cast_creates_None_from_null<T>(T? value) where T : class {
+        var maybe = Maybe.From<T>(value);
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<None<T>>(maybe);
+        Assert.AreSame(Maybe<T>.None, maybe);
+    }
+
+    #endregion
+
+    /// <summary>
+    ///   The <see cref="Maybe{T}"/> cast returns a <see cref="Some{T}"/> of the 
+    ///   correct wrapping the provided primitive value.
+    /// </summary>
+    [TestMethod]
+    public void MaybeT_cast_creates_Some_for_primitive_type_value() {
+        MaybeT_cast_creates_Some_from_value(TestEnum.E11);
+        MaybeT_cast_creates_Some_from_value(111);
+    }
+
+    /// <summary>
+    ///   The <see cref="Maybe{T}"/> cast returns a <see cref="Some{T}"/> of the 
+    ///   correct wrapping the provided nullable value type value.
+    /// </summary>
+    [TestMethod]
+    public void MaybeT_cast_creates_Some_for_nullable_primitive_type_value() {
+        MaybeT_cast_creates_Some_from_nullable_value(TestEnum.E11);
+        MaybeT_cast_creates_Some_from_nullable_value(111);
+    }
+
+    /// <summary>
+    ///   The <see cref="Maybe{T}"/> cast returns a <see cref="Some{T}"/> of the 
+    ///   correct wrapping the provided value type value.
+    /// </summary>
+    [TestMethod]
+    public void MaybeT_Cast_creates_Some_for_value_type_value() {
+        MaybeT_cast_creates_Some_from_value((111, "111"));
+        MaybeT_cast_creates_Some_from_value((decimal)111);
+    }
+
+    /// <summary>
+    ///   The <see cref="Maybe{T}"/> cast returns a <see cref="Some{T}"/> of the 
+    ///   correct wrapping the provided nullable value type value.
+    /// </summary>
+    [TestMethod]
+    public void MaybeT_cast_creates_Some_for_nullable_value_type_value() {
+        MaybeT_cast_creates_Some_from_nullable_value((111, "111"));
+        MaybeT_cast_creates_Some_from_nullable_value((decimal)111);
+    }
+
+    /// <summary>
+    ///   The <see cref="Maybe{T}"/> cast returns a <see cref="Some{T}"/> of the 
+    ///   correct wrapping the provided nullable reference type value.
+    /// </summary>
+    [TestMethod]
+    public void MaybeT_cast_creates_Some_for_reference_type_value() {
+        MaybeT_cast_creates_Some_from_reference_value("111");
+        MaybeT_cast_creates_Some_from_reference_value(new int[] { 111 });
+        MaybeT_cast_creates_Some_from_reference_value(new TestClass(111, "111"));
+    }
+
+    /// <summary>
+    ///   The <see cref="Maybe{T}"/> cast returns <see cref="Maybe{T}.None"/> singleton
+    ///   for the provided primitive type null value.
+    /// </summary>
+    [TestMethod]
+    public void MaybeT_cast_creates_None_for_primitive_type_null() {
+        MaybeT_cast_creates_None_from_null((TestEnum?)null);
+        MaybeT_cast_creates_None_from_null((int?)null);
+    }
+
+    /// <summary>
+    ///   The <see cref="Maybe{T}"/> cast returns <see cref="Maybe{T}.None"/> singleton
+    ///   for the provided value type null value.
+    /// </summary>
+    [TestMethod]
+    public void MaybeT_cast_creates_None_for_value_type_null() {
+        MaybeT_cast_creates_None_from_null(((int, string)?)null);
+        MaybeT_cast_creates_None_from_null((decimal?)null);
+    }
+
+    /// <summary>
+    ///   The <see cref="Maybe{T}"/> cast returns <see cref="Maybe{T}.None"/> singleton
+    ///   for the provided reference type null value.
+    /// </summary>
+    [TestMethod]
+    public void MaybeT_cast_creates_None_for_reference_type_null() {
+        MaybeT_cast_creates_None_from_null((string?)null);
+        MaybeT_cast_creates_None_from_null((int[]?)null);
+        MaybeT_cast_creates_None_from_null((TestClass?)null);
     }
 }

--- a/tests/Eithers.Tests/None{T}Tests.cs
+++ b/tests/Eithers.Tests/None{T}Tests.cs
@@ -17,7 +17,7 @@ public class Constructor_Tests {
     ///   The <see cref="None{T}"/> constructors' visibility is not public.
     /// </summary>
     [TestMethod]
-    public void MaybeT_constructors_are_private() {
+    public void NoneT_constructors_are_private() {
         var type = typeof(None<int>);
         var ctors = type.GetConstructors(
             BindingFlags.Public | BindingFlags.NonPublic |
@@ -55,7 +55,7 @@ public class EqualsT_Method_Tests {
     [TestMethod]
     public void NoneT_Equals_returns_false_for_value_types_values() {
         Assert.IsFalse(none.Equals(tupleValue));
-        Assert.IsFalse(none.Equals((Decimal)111));
+        Assert.IsFalse(none.Equals((decimal)111));
     }
 
     /// <summary>
@@ -76,67 +76,50 @@ public class EqualsT_Method_Tests {
 [TestClass]
 public class EqualsMaybeT_Method_Tests {
 
-    private readonly Maybe<int> none = Maybe<int>.None;
-
     /// <summary>
     ///   The <see cref="None{T}.Equals(Maybe{T})"/> method returns <see langword="true"/> for
     ///   <see cref="None{T}"/> of the same type.
     /// </summary>
     [TestMethod]
-    public void NoneT_Equals_returns_true_for_NoneT_of_same_type() =>
-        Assert.IsTrue(none.Equals(Maybe<int>.None));
+    public void NoneT_Equals_returns_true_for_NoneT_of_same_type() {
+        Assert.IsTrue(Maybe<TestEnum>.None.Equals(Maybe<TestEnum>.None));
+        Assert.IsTrue(Maybe<int>.None.Equals(Maybe<int>.None));
+        Assert.IsTrue(Maybe<(int, string)>.None.Equals(Maybe<(int, string)>.None));
+        Assert.IsTrue(Maybe<decimal>.None.Equals(Maybe<decimal>.None));
+        Assert.IsTrue(Maybe<string>.None.Equals(Maybe<string>.None));
+        Assert.IsTrue(Maybe<int[]>.None.Equals(Maybe<int[]>.None));
+        Assert.IsTrue(Maybe<TestClass>.None.Equals(Maybe<TestClass>.None));
+    }
 
     /// <summary>
     ///   The <see cref="None{T}.Equals(Maybe{T})"/> method returns <see langword="false"/> for
     ///   <see cref="None{T}"/> of the different types.
     /// </summary>
     [TestMethod]
-    public void NoneT_Equals_returns_false_for_NoneT_of_other_types() {
-        Assert.IsFalse(none.Equals(Maybe<TestEnum>.None));
-        Assert.IsFalse(none.Equals(Maybe<(int, string)>.None));
-        Assert.IsFalse(none.Equals(Maybe<Decimal>.None));
-        Assert.IsFalse(none.Equals(Maybe<string>.None));
-        Assert.IsFalse(none.Equals(Maybe<int[]>.None));
-        Assert.IsFalse(none.Equals(Maybe<TestClass>.None));
+    public void NoneT_Equals_returns_false_for_NoneT_of_different_types() {
+        Assert.IsFalse(Maybe<TestEnum>.None.Equals(Maybe<int>.None));
+        Assert.IsFalse(Maybe<int>.None.Equals(Maybe<TestEnum>.None));
+        Assert.IsFalse(Maybe<(int, string)>.None.Equals(Maybe<decimal>.None));
+        Assert.IsFalse(Maybe<decimal>.None.Equals(Maybe<(int, string)>.None));
+        Assert.IsFalse(Maybe<string>.None.Equals(Maybe<int[]>.None));
+        Assert.IsFalse(Maybe<int[]>.None.Equals(Maybe<TestClass>.None));
+        Assert.IsFalse(Maybe<TestClass>.None.Equals(Maybe<string>.None));
     }
 
     /// <summary>
     ///   The <see cref="None{T}.Equals(Maybe{T})"/> method returns <see langword="false"/> for
-    ///   <see cref="Some{T}"/> wrapping primitive types.
+    ///   <see cref="Some{T}"/>s.
     /// </summary>
     [TestMethod]
     public void NoneT_Equals_returns_false_for_SomeT_wrapping_primitive_types() {
-        Assert.IsFalse(none.Equals(Maybe.Some<TestEnum>(TestEnum.E11)));
-        Assert.IsFalse(none.Equals(Maybe.Some<int>(111)));
+        Assert.IsFalse(Maybe<TestEnum>.None.Equals(Maybe.Some(TestEnum.E11)));
+        Assert.IsFalse(Maybe<int>.None.Equals(Maybe.Some(111)));
+        Assert.IsFalse(Maybe<(int, string)>.None.Equals(Maybe.Some((111, "111"))));
+        Assert.IsFalse(Maybe<decimal>.None.Equals(Maybe.Some((decimal)111)));
+        Assert.IsFalse(Maybe<string>.None.Equals(Maybe.Some("111")));
+        Assert.IsFalse(Maybe<int[]>.None.Equals(Maybe.Some(new int[] { 111 })));
+        Assert.IsFalse(Maybe<TestClass>.None.Equals(Maybe.Some(new TestClass(111, "111"))));
     }
-
-    /// <summary>
-    ///   The <see cref="None{T}.Equals(Maybe{T})"/> method returns <see langword="false"/> for
-    ///   <see cref="Some{T}"/> wrapping value types.
-    /// </summary>
-    [TestMethod]
-    public void NoneT_Equals_returns_false_for_SomeT_wrapping_value_types() {
-        Assert.IsFalse(none.Equals(Maybe.Some<(int, string)>(tupleValue)));
-        Assert.IsFalse(none.Equals(Maybe.Some<Decimal>(111)));
-    }
-
-    /// <summary>
-    ///   The <see cref="None{T}.Equals(Maybe{T})"/> method returns <see langword="false"/> for
-    ///   <see cref="Some{T}"/> wrapping reference types.
-    /// </summary>
-    [TestMethod]
-    public void NoneT_Equals_returns_false_for_SomeT_wrapping_reference_types() {
-        Assert.IsFalse(none.Equals(Maybe.Some("111")));
-        Assert.IsFalse(none.Equals(Maybe.Some(arrayValue)));
-        Assert.IsFalse(none.Equals(Maybe.Some(classValue)));
-    }
-}
-
-/// <summary>
-///   Unit test for <see cref="Maybe{T}.Equals(object)"/> tests.
-/// </summary>
-[TestClass]
-public class EqualsObject_Method_Tests {
 }
 
 /// <summary>
@@ -144,6 +127,31 @@ public class EqualsObject_Method_Tests {
 /// </summary>
 [TestClass]
 public class GetEnumerator_Method_Tests {
+
+    #region test implementaions
+
+    private static void GetEnumerator_returns_correct_enumerator<T>() where T : notnull {
+        var enumerator = Maybe<T>.None.GetEnumerator();
+        Assert.IsInstanceOfType<IEnumerator<T>>(enumerator);
+        Assert.IsFalse(enumerator.MoveNext());
+    }
+
+    #endregion
+
+    /// <summary>
+    ///   The <see cref="None{T}.GetEnumerator"/> methods return a correct
+    ///   <see cref="IEnumerator{T}"/> for all types.
+    /// </summary>
+    [TestMethod]
+    public void SomeT_GetEnumerator_returns_correct_enumerator_for_primitive_types() {
+        GetEnumerator_returns_correct_enumerator<int>();
+        GetEnumerator_returns_correct_enumerator<TestEnum>();
+        GetEnumerator_returns_correct_enumerator<(int, string)>();
+        GetEnumerator_returns_correct_enumerator<decimal>();
+        GetEnumerator_returns_correct_enumerator<string>();
+        GetEnumerator_returns_correct_enumerator<int[]>();
+        GetEnumerator_returns_correct_enumerator<TestClass>();
+    }
 }
 
 /// <summary>
@@ -166,9 +174,10 @@ public class GetHashCode_Method_Tests {
     [TestMethod]
     public void NoneT_GetHashCode_returns_statistically_unique_value() {
         var noneHashCode = none.GetHashCode();
-        Assert.AreNotEqual(noneHashCode, Maybe<TestEnum>.None.GetHashCode());
-        Assert.AreNotEqual(noneHashCode, Maybe<(int, string)>.None.GetHashCode());
-        Assert.AreNotEqual(noneHashCode, Maybe<Decimal>.None.GetHashCode());
+        Assert.AreNotEqual(Maybe<TestEnum>.None.GetHashCode(), Maybe<int>.None.GetHashCode());
+        Assert.AreNotEqual(Maybe<int>.None.GetHashCode(), Maybe<TestEnum>.None.GetHashCode());
+        Assert.AreNotEqual(Maybe<(int, string)>.None.GetHashCode(), Maybe<decimal>.None.GetHashCode());
+        Assert.AreNotEqual(Maybe<decimal>.None.GetHashCode(), Maybe<(int, string)>.None.GetHashCode());
         Assert.AreNotEqual(noneHashCode, Maybe<string>.None.GetHashCode());
         Assert.AreNotEqual(noneHashCode, Maybe<int[]>.None.GetHashCode());
         Assert.AreNotEqual(noneHashCode, Maybe<TestClass>.None.GetHashCode());
@@ -184,30 +193,14 @@ public class HasValue_Property_Tests {
 
     /// <summary>
     ///   The <see cref="None{T}.HasValue"/> property returns <see langword="false"/>
-    ///   for primitive types.
+    ///   for all types.
     /// </summary>
     [TestMethod]
     public void NoneT_HasValue_returns_false_for_primitive_types() {
         Assert.IsFalse(Maybe<int>.None.HasValue);
         Assert.IsFalse(Maybe<TestEnum>.None.HasValue);
-    }
-
-    /// <summary>
-    ///   The <see cref="None{T}.HasValue"/> property returns <see langword="false"/>
-    ///   for value types.
-    /// </summary>
-    [TestMethod]
-    public void NoneT_HasValue_returns_false_for_value_types() {
         Assert.IsFalse(Maybe<TestStruct>.None.HasValue);
         Assert.IsFalse(Maybe<(int, string)>.None.HasValue);
-    }
-
-    /// <summary>
-    ///   The <see cref="None{T}.HasValue"/> property returns <see langword="false"/>
-    ///   for reference types.
-    /// </summary>
-    [TestMethod]
-    public void NoneT_HasValue_returns_false_for_reference_types() {
         Assert.IsFalse(Maybe<string>.None.HasValue);
         Assert.IsFalse(Maybe<int[]>.None.HasValue);
         Assert.IsFalse(Maybe<TestClass>.None.HasValue);

--- a/tests/Eithers.Tests/Some{T}Tests.cs
+++ b/tests/Eithers.Tests/Some{T}Tests.cs
@@ -14,25 +14,54 @@ namespace SomeT_Tests;
 [TestClass]
 public class Cast_Tests {
 
-    /// <summary>
-    ///   The <see cref="Some{T}"/> cast creates the correct type
-    ///   and wraps the correct value.
-    /// </summary>
-    [TestMethod]
-    public void SomeT_SomeT_cast_creates_correct_SomeT_type_and_value() {
+    #region test implementations
+
+    private static void SomeT_case_creates_Some_from_value<T>(T value) where T: notnull {
 
         // explicit cast
-        var some = (Some<int>)111;
-        Assert.IsInstanceOfType<Some<int>>(some);
-        Assert.IsInstanceOfType<Maybe<int>>(some);
-        Assert.AreEqual(111, some.Value);
+        var some = (Some<T>)value;
+        Assert.IsInstanceOfType<Some<T>>(some);
+        Assert.IsInstanceOfType<Maybe<T>>(some);
+        Assert.AreEqual(value, some.Value);
 
         // implicit cast
-        Some<int> some2 = 111;
-        Assert.IsInstanceOfType<Some<int>>(some2);
-        Assert.IsInstanceOfType<Maybe<int>>(some2);
-        Assert.AreEqual(111, some2.Value);
+        Some<T> some2 = value;
+        Assert.IsInstanceOfType<Some<T>>(some2);
+        Assert.IsInstanceOfType<Maybe<T>>(some2);
+        Assert.AreEqual(value, some2.Value);
+    }
 
+    #endregion
+
+    /// <summary>
+    ///   The <see cref="Some{T}"/> cast creates the correct type
+    ///   and wraps the correct value for primitive types.
+    /// </summary>
+    [TestMethod]
+    public void SomeT_cast_creates_correct_SomeT_for_primitive_types() {
+        SomeT_case_creates_Some_from_value(TestEnum.E11);
+        SomeT_case_creates_Some_from_value(111);
+    }
+
+    /// <summary>
+    ///   The <see cref="Some{T}"/> cast creates the correct type
+    ///   and wraps the correct value for value types.
+    /// </summary>
+    [TestMethod]
+    public void SomeT_cast_creates_correct_SomeT_for_value_types() {
+        SomeT_case_creates_Some_from_value((111, "111"));
+        SomeT_case_creates_Some_from_value((decimal)111);
+    }
+
+    /// <summary>
+    ///   The <see cref="Some{T}"/> cast creates the correct type
+    ///   and wraps the correct value for reference types.
+    /// </summary>
+    [TestMethod]
+    public void SomeT_cast_creates_correct_SomeT_reference_types() {
+        SomeT_case_creates_Some_from_value("111");
+        SomeT_case_creates_Some_from_value(new int[] { 111 });
+        SomeT_case_creates_Some_from_value(new TestClass(111, "111"));
     }
 }
 
@@ -41,6 +70,20 @@ public class Cast_Tests {
 /// </summary>
 [TestClass]
 public class Constructor_Tests {
+
+    #region test implementations
+
+    private static void SomeT_constructor_creates_SomeT<T>(T value) where T: notnull {
+        var some = new Some<T>(value);
+        Assert.IsInstanceOfType<Some<T>>(some);
+        Assert.IsInstanceOfType<Maybe<T>>(some);
+        Assert.AreEqual(value, some.Value);
+    }
+
+    private static void SomeT_constructor_throws_for_null<T>() where T : class =>
+        Assert.ThrowsException<ArgumentNullException>(() => new Some<T>(null!));
+
+    #endregion
 
     /// <summary>
     ///   The <see cref="Some{T}"/> constructors' visibility is not public.
@@ -60,20 +103,45 @@ public class Constructor_Tests {
     }
 
     /// <summary>
-    ///   The <see cref="Some{T}"/> constructor creates the correct type
-    ///   and wraps the correct value.
+    ///   The <see cref="Some{T}"/> constructor creates the correct <see cref="Some{T}"/>
+    ///   and wraps the correct value for primitive types.
     /// </summary>
     [TestMethod]
-    public void SomeT_constructor_creates_correct_SomeT_type_and_value() {
-        var some = new Some<int>(111);
-        Assert.IsInstanceOfType<Some<int>>(some);
-        Assert.IsInstanceOfType<Maybe<int>>(some);
-        Assert.AreEqual(111, some.Value);
+    public void SomeT_constructor_creates_SomeT_for_primitive_types() {
+        SomeT_constructor_creates_SomeT(TestEnum.E11);
+        SomeT_constructor_creates_SomeT(111);
     }
 
+    /// <summary>
+    ///   The <see cref="Some{T}"/> constructor creates the correct <see cref="Some{T}"/>
+    ///   and wraps the correct value for value types.
+    /// </summary>
     [TestMethod]
-    public void SomeT_constructor_throws_for_null_value() {
-        Assert.ThrowsException<ArgumentNullException>(() => new Some<string>(null!));
+    public void SomeT_constructor_creates_SomeT_for_value_types() {
+        SomeT_constructor_creates_SomeT((111, "111"));
+        SomeT_constructor_creates_SomeT((decimal)111);
+    }
+
+    /// <summary>
+    ///   The <see cref="Some{T}"/> constructor creates the correct <see cref="Some{T}"/>
+    ///   and wraps the correct value for reference types.
+    /// </summary>
+    [TestMethod]
+    public void SomeT_constructor_creates_SomeT_for_reference_types() {
+        SomeT_constructor_creates_SomeT("111");
+        SomeT_constructor_creates_SomeT(new int[] { 111 });
+        SomeT_constructor_creates_SomeT(new TestClass(111, "111"));
+    }
+
+    /// <summary>
+    ///   The <see cref="Some{T}"/> constructor throws <see cref="ArgumentNullException"/>
+    ///   for null reference types.
+    /// </summary>
+    [TestMethod]
+    public void SomeT_constructor_throws_for_null_reference_types() {
+        SomeT_constructor_throws_for_null<string>();
+        SomeT_constructor_throws_for_null<int[]>();
+        SomeT_constructor_throws_for_null<TestClass>();
     }
 }
 
@@ -83,16 +151,30 @@ public class Constructor_Tests {
 [TestClass]
 public class EqualsT_Method_Tests {
 
+    #region test implementations
+
+    private static void EqualsT_returns_true_for_same_value<T>(T value)
+            where T : notnull {
+        var some = new Some<T>(value);
+        Assert.IsTrue(some.Equals(value));
+    }
+
+    private static void EqualsT_returns_true_for_different_value<T>(T value, T value2)
+            where T : notnull {
+        var some = new Some<T>(value);
+        Assert.IsFalse(some.Equals(value2));
+    }
+
+    #endregion
+
     /// <summary>
     ///  The <see cref="Some{T}.Equals(T)"/> method returns <see langword="true"/>
-    ///  for primitive types with the same values.
+    ///  for primitive types with the same value.
     /// </summary>
     [TestMethod]
     public void SomeT_EqualsT_returns_true_for_primitive_types_with_the_same_value() {
-        var intSome = new Some<int>(111);
-        Assert.IsTrue(intSome.Equals(111));
-        var enumSome = new Some<TestEnum>(TestEnum.E11);
-        Assert.IsTrue(enumSome.Equals(TestEnum.E11));
+        EqualsT_returns_true_for_same_value(TestEnum.E11);
+        EqualsT_returns_true_for_same_value(111);
     }
 
     /// <summary>
@@ -101,10 +183,8 @@ public class EqualsT_Method_Tests {
     /// </summary>
     [TestMethod]
     public void SomeT_EqualsT_returns_true_for_value_types_with_the_same_value() {
-        var tupleSome = new Some<(int, string)>((111, "111"));
-        Assert.IsTrue(tupleSome.Equals((111, "111")));
-        var decimalSome = new Some<Decimal>(111);
-        Assert.IsTrue(decimalSome.Equals(111));
+        EqualsT_returns_true_for_same_value((111, "111"));
+        EqualsT_returns_true_for_same_value((decimal)111);
     }
 
     /// <summary>
@@ -117,16 +197,9 @@ public class EqualsT_Method_Tests {
         // Note: string overrides Equals to compare by value.
         // All other reference types compare by reference.
 
-        var stringSome = new Some<string>("111");
-        Assert.IsTrue(stringSome.Equals("111"));
-
-        var arrayValue = new int[] { 111 };
-        var arraySome = new Some<int[]>(arrayValue);
-        Assert.IsTrue(arraySome.Equals(arrayValue));
-
-        var classValue = new TestClass(111, "111");
-        var classSome = new Some<TestClass>(classValue);
-        Assert.IsTrue(classSome.Equals(classValue));
+        EqualsT_returns_true_for_same_value("111");
+        EqualsT_returns_true_for_same_value(new int[] { 111 });
+        EqualsT_returns_true_for_same_value(new TestClass(111, "111"));
     }
 
     /// <summary>
@@ -134,11 +207,9 @@ public class EqualsT_Method_Tests {
     ///  for primitive types with the same values.
     /// </summary>
     [TestMethod]
-    public void SomeT_EqualsT_returns_false_for_primitive_types_with_the_different_value() {
-        var intSome = new Some<int>(111);
-        Assert.IsFalse(intSome.Equals(222));
-        var enumSome = new Some<TestEnum>(TestEnum.E11);
-        Assert.IsFalse(enumSome.Equals(TestEnum.E22));
+    public void SomeT_EqualsT_returns_false_for_primitive_types_with_different_value() {
+        EqualsT_returns_true_for_different_value(111, 222);
+        EqualsT_returns_true_for_different_value(TestEnum.E11, TestEnum.E22);
     }
 
     /// <summary>
@@ -147,10 +218,8 @@ public class EqualsT_Method_Tests {
     /// </summary>
     [TestMethod]
     public void SomeT_EqualsT_returns_false_for_value_types_with_the_different_value() {
-        var tupleSome = new Some<(int, string)>((111, "111"));
-        Assert.IsFalse(tupleSome.Equals((222, "222")));
-        var decimalSome = new Some<Decimal>(111);
-        Assert.IsFalse(decimalSome.Equals(222));
+        EqualsT_returns_true_for_different_value((111, "111"), (222, "222"));
+        EqualsT_returns_true_for_different_value((decimal)111, (decimal)222);
     }
 
     /// <summary>
@@ -163,16 +232,10 @@ public class EqualsT_Method_Tests {
         // Note: string overrides Equals to compare by value.
         // All other reference types compare by reference.
 
-        var stringSome = new Some<string>("111");
-        Assert.IsFalse(stringSome.Equals("222"));
-
-        var arrayValue = new int[] { 111 };
-        var arraySome = new Some<int[]>(arrayValue);
-        Assert.IsFalse(arraySome.Equals(new int[] { 222 }));
-
-        var classValue = new TestClass(111, "111");
-        var classSome = new Some<TestClass>(classValue);
-        Assert.IsFalse(classSome.Equals(new TestClass(222, "222")));
+        EqualsT_returns_true_for_different_value("111", "222");
+        EqualsT_returns_true_for_different_value(new int[] { 111 }, new int[] { 222 });
+        EqualsT_returns_true_for_different_value(
+            new TestClass(111, "111"), new TestClass(222, "222"));
     }
 }
 
@@ -180,18 +243,39 @@ public class EqualsT_Method_Tests {
 ///   Unit tests for the <see cref="Some{T}.Equals(Maybe{T})"/> methods.
 /// </summary>
 [TestClass]
-public class EqualsMaybeT_Method_Tests {
+public class Equals_MaybeT_Method_Tests {
+
+    #region test implementations
+
+    private static void Equals_MaybeT_returns_true_for_same_value<T>(T value) where T : notnull {
+        var maybe = new Some<T>(value);
+        var maybe2 = new Some<T>(value);
+        Assert.IsTrue(maybe.Equals(maybe2));
+    }
+
+    private static void Equals_MaybeT_returns_false_for_different_value<T>(T value, T value2)
+            where T : notnull {
+        var maybe = new Some<T>(value);
+        var maybe2 = new Some<T>(value2);
+        Assert.IsFalse(maybe.Equals(maybe2));
+    }
+
+    private static void Equals_MaybeT_returns_false_for_None<T>(T value)
+            where T : notnull {
+        var maybe = new Some<T>(value);
+        Assert.IsFalse(maybe.Equals(Maybe<T>.None));
+    }
+
+    #endregion
 
     /// <summary>
     ///  The <see cref="Some{T}.Equals(T)"/> method returns <see langword="true"/>
     ///  for primitive types with the same values.
     /// </summary>
     [TestMethod]
-    public void SomeT_EqualsMaybeT_returns_true_for_primitive_types_with_the_same_value() {
-        var intSome = new Some<int>(111);
-        Assert.IsTrue(intSome.Equals(new Some<int>(111)));
-        var enumSome = new Some<TestEnum>(TestEnum.E11);
-        Assert.IsTrue(enumSome.Equals(new Some<TestEnum>(TestEnum.E11)));
+    public void SomeT_EqualsMaybeT_returns_true_for_primitive_type_with_the_same_value() {
+        Equals_MaybeT_returns_true_for_same_value(111);
+        Equals_MaybeT_returns_true_for_same_value(TestEnum.E11);
     }
 
     /// <summary>
@@ -199,11 +283,9 @@ public class EqualsMaybeT_Method_Tests {
     ///  for value types with the same values.
     /// </summary>
     [TestMethod]
-    public void SomeT_EqualsMaybeT_returns_true_for_value_types_with_the_same_value() {
-        var tupleSome = new Some<(int, string)>((111, "111"));
-        Assert.IsTrue(tupleSome.Equals(new Some<(int, string)>((111, "111"))));
-        var decimalSome = new Some<Decimal>(111);
-        Assert.IsTrue(decimalSome.Equals(new Some<Decimal>(111)));
+    public void SomeT_EqualsMaybeT_returns_true_for_value_type_with_the_same_value() {
+        Equals_MaybeT_returns_true_for_same_value((111, "111"));
+        Equals_MaybeT_returns_true_for_same_value((decimal)111);
     }
 
     /// <summary>
@@ -211,95 +293,75 @@ public class EqualsMaybeT_Method_Tests {
     ///  for reference types with the same values.
     /// </summary>
     [TestMethod]
-    public void SomeT_EqualsMaybeT_returns_true_for_reference_types_with_the_same_value() {
+    public void SomeT_EqualsMaybeT_returns_true_for_reference_type_with_the_same_value() {
 
         // Note: string overrides Equals to compare by value.
         // All other reference types compare by reference.
 
-        var stringSome = new Some<string>("111");
-        Assert.IsTrue(stringSome.Equals(new Some<string>("111")));
-
-        var arrayValue = new int[] { 111 };
-        var arraySome = new Some<int[]>(arrayValue);
-        Assert.IsTrue(arraySome.Equals(new Some<int[]>(arrayValue)));
-
-        var classValue = new TestClass(111, "111");
-        var classSome = new Some<TestClass>(classValue);
-        Assert.IsTrue(classSome.Equals(new Some<TestClass>(classValue)));
+        Equals_MaybeT_returns_true_for_same_value("111");
+        Equals_MaybeT_returns_true_for_same_value(new int[] { 111 });
+        Equals_MaybeT_returns_true_for_same_value(new TestClass(111, "111"));
     }
 
     /// <summary>
-    ///  The <see cref="Some{T}.Equals(Maybe{T})"/> method returns <see langword="true"/>
-    ///  for primitive types with the same values.
+    ///  The <see cref="Some{T}.Equals(Maybe{T})"/> method returns <see langword="false"/>
+    ///  for primitive types with the different value.
     /// </summary>
     [TestMethod]
-    public void SomeT_EqualsMaybeT_returns_false_for_primitive_types_with_the_different_value() {
-        var intSome = new Some<int>(111);
-        Assert.IsFalse(intSome.Equals(new Some<int>(222)));
-        var enumSome = new Some<TestEnum>(TestEnum.E11);
-        Assert.IsFalse(enumSome.Equals(new Some<TestEnum>(TestEnum.E22)));
+    public void SomeT_EqualsMaybeT_returns_false_for_primitive_type_with_the_different_value() {
+        Equals_MaybeT_returns_false_for_different_value(111, 222);
+        Equals_MaybeT_returns_false_for_different_value(TestEnum.E11, TestEnum.E22);
     }
 
     /// <summary>
-    ///  The <see cref="Some{T}.Equals(Maybe{T})"/> method returns <see langword="true"/>
-    ///  for value types with the same values.
+    ///  The <see cref="Some{T}.Equals(Maybe{T})"/> method returns <see langword="false"/>
+    ///  for value types with the different value.
     /// </summary>
     [TestMethod]
-    public void SomeT_EqualsMaybeT_returns_false_for_value_types_with_the_different_value() {
-        var tupleSome = new Some<(int, string)>((111, "111"));
-        Assert.IsFalse(tupleSome.Equals(new Some<(int, string)>((222, "222"))));
-        var decimalSome = new Some<Decimal>(111);
-        Assert.IsFalse(decimalSome.Equals(new Some<Decimal>(222)));
+    public void SomeT_EqualsMaybeT_returns_false_for_value_type_with_the_different_value() {
+        Equals_MaybeT_returns_false_for_different_value((111, "111"), (222, "222"));
+        Equals_MaybeT_returns_false_for_different_value((decimal)111, (decimal)222);
     }
 
     /// <summary>
-    ///  The <see cref="Some{T}.Equals(Maybe{T})"/> method returns <see langword="true"/>
-    ///  for reference types with the same values.
+    ///  The <see cref="Some{T}.Equals(Maybe{T})"/> method returns <see langword="false"/>
+    ///  for reference types with the different value.
     /// </summary>
     [TestMethod]
-    public void SomeT_EqualsMaybeT_returns_false_for_reference_types_with_the_different_value() {
+    public void SomeT_EqualsMaybeT_returns_false_for_reference_type_with_the_different_value() {
 
         // Note: string overrides Equals to compare by value.
         // All other reference types compare by reference.
 
-        var stringSome = new Some<string>("111");
-        Assert.IsFalse(stringSome.Equals(new Some<string>("222")));
-
-        var arrayValue = new int[] { 111 };
-        var arraySome = new Some<int[]>(arrayValue);
-        Assert.IsFalse(arraySome.Equals(new Some<int[]>(new int[] { 222 })));
-
-        var classValue = new TestClass(111, "111");
-        var classSome = new Some<TestClass>(classValue);
-        Assert.IsFalse(classSome.Equals(new Some<TestClass>(new TestClass(222, "222"))));
+        Equals_MaybeT_returns_false_for_different_value("111", "222");
+        Equals_MaybeT_returns_false_for_different_value(new int[] { 111 }, new int[] { 222 });
+        Equals_MaybeT_returns_false_for_different_value(
+            new TestClass(111, "111"), new TestClass(222, "222"));
     }
+
     /// <summary>
-    ///  The <see cref="Some{T}.Equals(T)"/> method returns <see langword="true"/>
-    ///  for primitive types with the same values.
+    ///  The <see cref="Some{T}.Equals(T)"/> method returns <see langword="false"/>
+    ///  for primitive type <see cref="Maybe{T}.None"/>.
     /// </summary>
     [TestMethod]
     public void SomeT_EqualsMaybeT_returns_false_for_primitive_types_with_no_value() {
-        var intSome = new Some<int>(111);
-        Assert.IsFalse(intSome.Equals(Maybe<int>.None));
-        var enumSome = new Some<TestEnum>(TestEnum.E11);
-        Assert.IsFalse(enumSome.Equals(Maybe<TestEnum>.None));
+        Equals_MaybeT_returns_false_for_None(111);
+        Equals_MaybeT_returns_false_for_None(TestEnum.E11);
     }
 
     /// <summary>
-    ///  The <see cref="Some{T}.Equals(T)"/> method returns <see langword="true"/>
-    ///  for value types with the same values.
+    ///  The <see cref="Some{T}.Equals(T)"/> method returns <see langword="false"/>
+    ///  for value type <see cref="Maybe{T}.None"/>.
     /// </summary>
     [TestMethod]
     public void SomeT_EqualsMaybeT_returns_false_for_value_types_with_no_value() {
-        var tupleSome = new Some<(int, string)>((111, "111"));
-        Assert.IsFalse(tupleSome.Equals(Maybe<(int, string)>.None));
-        var decimalSome = new Some<Decimal>(111);
-        Assert.IsFalse(decimalSome.Equals(Maybe<Decimal>.None));
+        Equals_MaybeT_returns_false_for_None((111, "111"));
+        Equals_MaybeT_returns_false_for_None((decimal)111);
     }
 
     /// <summary>
-    ///  The <see cref="None{T}.Equals(T)"/> method returns <see langword="true"/>
-    ///  for reference types with the same values.
+    ///  The <see cref="None{T}.Equals(T)"/> method returns <see langword="false"/>
+    ///  for reference type <see cref="Maybe{T}.None"/>.
     /// </summary>
     [TestMethod]
     public void SomeT_EqualsMaybeT_returns_false_for_reference_types_with_no_value() {
@@ -307,16 +369,9 @@ public class EqualsMaybeT_Method_Tests {
         // Note: string overrides Equals to compare by value.
         // All other reference types compare by reference.
 
-        var stringSome = new Some<string>("111");
-        Assert.IsFalse(stringSome.Equals(Maybe<string>.None));
-
-        var arrayValue = new int[] { 111 };
-        var arraySome = new Some<int[]>(arrayValue);
-        Assert.IsFalse(arraySome.Equals(Maybe<int[]>.None));
-
-        var classValue = new TestClass(111, "111");
-        var classSome = new Some<TestClass>(classValue);
-        Assert.IsFalse(classSome.Equals(Maybe<TestClass>.None));
+        Equals_MaybeT_returns_false_for_None("111");
+        Equals_MaybeT_returns_false_for_None(new int[] { 111 });
+        Equals_MaybeT_returns_false_for_None(new TestClass(111, "111"));
     }
 }
 
@@ -326,18 +381,48 @@ public class EqualsMaybeT_Method_Tests {
 [TestClass]
 public class GetEnumerator_Method_Tests {
 
+    #region test implementaions
+
+    private static void GetEnumerator_returns_correct_enumerator<T>(T value) where T: notnull {
+        var some = new Some<T>(value);
+        var enumerator = some.GetEnumerator();
+        Assert.IsInstanceOfType<IEnumerator<T>>(enumerator);
+        Assert.IsTrue(enumerator.MoveNext());
+        Assert.AreEqual(value, enumerator.Current);
+        Assert.IsFalse(enumerator.MoveNext());
+    }
+
+    #endregion
+
     /// <summary>
     ///   The <see cref="Some{T}.GetEnumerator"/> methods return a correct
-    ///   <see cref="IEnumerator{T}"/> for a <see cref="Some{T}"/>.
+    ///   <see cref="IEnumerator{T}"/> for a primitive types.
     /// </summary>
     [TestMethod]
-    public void SomeT_GetEnumerator_returns_correct_enumerator() {
-        var some = new Some<int>(111);
-        var enumerator = some.GetEnumerator();
-        Assert.IsInstanceOfType<IEnumerator<int>>(enumerator);
-        Assert.IsTrue(enumerator.MoveNext());
-        Assert.AreEqual(111, enumerator.Current);
-        Assert.IsFalse(enumerator.MoveNext());
+    public void SomeT_GetEnumerator_returns_correct_enumerator_for_primitive_types() {
+        GetEnumerator_returns_correct_enumerator(111);
+        GetEnumerator_returns_correct_enumerator(TestEnum.E11);
+    }
+
+    /// <summary>
+    ///   The <see cref="Some{T}.GetEnumerator"/> methods return a correct
+    ///   <see cref="IEnumerator{T}"/> for a primitive types.
+    /// </summary>
+    [TestMethod]
+    public void SomeT_GetEnumerator_returns_correct_enumerator_for_value_types() {
+        GetEnumerator_returns_correct_enumerator((111, "111"));
+        GetEnumerator_returns_correct_enumerator((decimal)111);
+    }
+
+    /// <summary>
+    ///   The <see cref="Some{T}.GetEnumerator"/> methods return a correct
+    ///   <see cref="IEnumerator{T}"/> for a primitive types.
+    /// </summary>
+    [TestMethod]
+    public void SomeT_GetEnumerator_returns_correct_enumerator_for_reference_types() {
+        GetEnumerator_returns_correct_enumerator("111");
+        GetEnumerator_returns_correct_enumerator(new int[] { 111 });
+        GetEnumerator_returns_correct_enumerator(new TestClass(111, "111"));
     }
 }
 
@@ -347,24 +432,58 @@ public class GetEnumerator_Method_Tests {
 [TestClass]
 public class GetHashCode_Method_Tests {
 
+    #region teset implementations
+
+    private static void GetHashCode_returns_hash_value_derived_from_wrapped_value<T>(
+            T value, T value2)
+            where T: notnull {
+        var maybe = new Some<T>(value);
+        Assert.AreEqual(value.GetHashCode(), maybe.GetHashCode());
+        Assert.AreNotEqual(value2.GetHashCode(), maybe.GetHashCode());
+    }
+
+    #endregion
+
     /// <summary>
-    ///   The <see cref="None{T}.GetHashCode"/> method returns a statistically-unique
-    ///   for each different <see cref="None{T}"/> type.
+    ///   The <see cref="None{T}.GetHashCode"/> method returns a hash code computed
+    ///   from the wrapped value for primtive type.
+    /// </summary>
+    [TestMethod]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Globalization", "CA1307:Specify StringComparison for clarity",
+        Justification = "StringComparison cannot be used within Maybe<T>")]
+    public void SomeT_GetHashCode_returns_hash_value_derived_from_wrapped_value_for_primitive_types() {
+        GetHashCode_returns_hash_value_derived_from_wrapped_value(111, 222);
+        GetHashCode_returns_hash_value_derived_from_wrapped_value(TestEnum.E11, TestEnum.E22);
+    }
+
+    /// <summary>
+    ///   The <see cref="None{T}.GetHashCode"/> method returns a hash code computed
+    ///   from the wrapped value for value types.
+    /// </summary>
+    [TestMethod]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Globalization", "CA1307:Specify StringComparison for clarity",
+        Justification = "StringComparison cannot be used within Maybe<T>")]
+    public void SomeT_GetHashCode_returns_hash_value_derived_from_wrapped_value_for_value_types() {
+        GetHashCode_returns_hash_value_derived_from_wrapped_value((111, "111"), (222, "222"));
+        GetHashCode_returns_hash_value_derived_from_wrapped_value((decimal)111, (decimal)222);
+    }
+
+    /// <summary>
+    ///   The <see cref="None{T}.GetHashCode"/> method returns a hash code computed
+    ///   from the wrapped value for reference types.
     /// </summary>
     [TestMethod]
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "Globalization", "CA1307:Specify StringComparison for clarity",
         Justification = "StringComparison cannot be used within Maybe<T>")]
     public void SomeT_GetHashCode_returns_hash_value_derived_from_wrapped_value_for_reference_types() {
-        var stringMaybe = Maybe.From("111");
-        Assert.AreEqual("111".GetHashCode(), stringMaybe.GetHashCode());
-        Assert.AreNotEqual("222".GetHashCode(), stringMaybe.GetHashCode());
-        var arrayMaybe = Maybe.From(arrayValue);
-        Assert.AreEqual(arrayValue.GetHashCode(), arrayMaybe.GetHashCode());
-        Assert.AreNotEqual(arrayValue2.GetHashCode(), arrayMaybe.GetHashCode());
-        var classMaybe = Maybe.From(classValue);
-        Assert.AreEqual(classValue.GetHashCode(), classMaybe.GetHashCode());
-        Assert.AreNotEqual(classValue2.GetHashCode(), classMaybe.GetHashCode());
+        GetHashCode_returns_hash_value_derived_from_wrapped_value("111", "222");
+        GetHashCode_returns_hash_value_derived_from_wrapped_value(
+            new int[] { 111 }, new int[] { 222 });
+        GetHashCode_returns_hash_value_derived_from_wrapped_value(
+            new TestClass(111, "111"), new TestClass(222, "222"));
     }
 }
 
@@ -374,16 +493,23 @@ public class GetHashCode_Method_Tests {
 [TestClass]
 public class HasValue_Property_Tests {
 
+    #region test implementations
+
+    private static void HasValue_returns_true<T>(T value) where T: notnull {
+        var some = new Some<T>(value);
+        Assert.IsTrue(some.HasValue);
+    }
+
+    #endregion
+
     /// <summary>
     ///   The <see cref="Some{T}.HasValue"/> property returns <see langword="true"/>
     ///   for primitive types.
     /// </summary>
     [TestMethod]
     public void SomeT_HasValue_returns_true_for_primitive_types() {
-        var intSome = new Some<int>(111);
-        Assert.IsTrue(intSome.HasValue);
-        var enumSome = new Some<TestEnum>(TestEnum.E11);
-        Assert.IsTrue(enumSome.HasValue);
+        HasValue_returns_true(111);
+        HasValue_returns_true(TestEnum.E11);
     }
 
     /// <summary>
@@ -392,8 +518,8 @@ public class HasValue_Property_Tests {
     /// </summary>
     [TestMethod]
     public void SomeT_HasValue_returns_true_for_value_types() {
-        Assert.IsFalse(Maybe<TestStruct>.None.HasValue);
-        Assert.IsFalse(Maybe<(int, string)>.None.HasValue);
+        HasValue_returns_true((111, "111"));
+        HasValue_returns_true((decimal)111);
     }
 
     /// <summary>
@@ -402,9 +528,9 @@ public class HasValue_Property_Tests {
     /// </summary>
     [TestMethod]
     public void SomeT_HasValue_returns_true_for_reference_types() {
-        Assert.IsFalse(Maybe<string>.None.HasValue);
-        Assert.IsFalse(Maybe<int[]>.None.HasValue);
-        Assert.IsFalse(Maybe<TestClass>.None.HasValue);
+        HasValue_returns_true("111");
+        HasValue_returns_true(new int[] { 111 });
+        HasValue_returns_true(new TestClass(111, "111"));
     }
 }
 
@@ -414,13 +540,43 @@ public class HasValue_Property_Tests {
 [TestClass]
 public class Value_Property_Tests {
 
+    #region
+
+    private static void Value_is_initialized_to_correct_value<T>(T value) where T : notnull {
+        var some = new Some<T>(value);
+        Assert.AreEqual(value, some.Value);
+    }
+
+    #endregion
+
     /// <summary>
     ///   The <see cref="Some{T}.Value"/> property returns the value provided to
-    ///   the constructor.
+    ///   the constructor for primitive types.
     /// </summary>
     [TestMethod]
-    public void SomeT_Value_is_initialized_to_correct_value() {
-        var some = new Some<int>(111);
-        Assert.AreEqual(111, some.Value);
+    public void SomeT_Value_is_initialized_to_correct_value_for_primitive_types() {
+        Value_is_initialized_to_correct_value(111);
+        Value_is_initialized_to_correct_value(TestEnum.E11);
+    }
+
+    /// <summary>
+    ///   The <see cref="Some{T}.Value"/> property returns the value provided to
+    ///   the constructor for value types.
+    /// </summary>
+    [TestMethod]
+    public void SomeT_Value_is_initialized_to_correct_value_for_value_types() {
+        Value_is_initialized_to_correct_value((111, "111"));
+        Value_is_initialized_to_correct_value((decimal)111);
+    }
+
+    /// <summary>
+    ///   The <see cref="Some{T}.Value"/> property returns the value provided to
+    ///   the constructor for reference types.
+    /// </summary>
+    [TestMethod]
+    public void SomeT_Value_is_initialized_to_correct_value_for_reference_types() {
+        Value_is_initialized_to_correct_value("111");
+        Value_is_initialized_to_correct_value(new int[] { 111 });
+        Value_is_initialized_to_correct_value(new TestClass(111, "111"));
     }
 }


### PR DESCRIPTION
- Refactor redundant code in class `Maybe`
- Refactor redundant code in class `Maybe<T>`
- Refactor redundant code in class `None<T>`
- Refactor redundant code in class `Some<T>`
- Add additional tests for `None<T>`

resolves #5 
