### PR TITLE
Refactor and cleanup driven by SonarLint (#15)

### DIFF
--- a/src/Eithers/Ainsworth.Eithers.csproj
+++ b/src/Eithers/Ainsworth.Eithers.csproj
@@ -20,5 +20,6 @@
 		<AnalysisMode>All</AnalysisMode>
 		<AnalysisLevel>5</AnalysisLevel>
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 </Project>

--- a/src/Eithers/CSharpShims/System_Runtime_CompilerServices.cs
+++ b/src/Eithers/CSharpShims/System_Runtime_CompilerServices.cs
@@ -1,8 +1,7 @@
-#nullable enable
-
 namespace System.Runtime.CompilerServices;
 
 /// <summary>
 /// An ugly hack to allow C# 9 features in C# Standard.
 /// </summary>
+#pragma warning disable S2094 // Classes should not be empty
 internal static class IsExternalInit { }

--- a/src/Eithers/ComparableNone{T}.cs
+++ b/src/Eithers/ComparableNone{T}.cs
@@ -1,5 +1,3 @@
-//#nullable enable
-
 //using System;
 
 //namespace Ainsworth.Eithers;
@@ -17,7 +15,7 @@
 //    protected ComparableNone() { }
 
 //    #endregion
-//    #region IComparible<T> Implementation
+//    #region IComparable<T> Implementation
 
 //    public int CompareTo(IComparableMaybe<T> other) => other.IsNone ? 0 : -1;
 

--- a/src/Eithers/ComparableSome{T}.cs
+++ b/src/Eithers/ComparableSome{T}.cs
@@ -1,5 +1,3 @@
-//#nullable enable
-
 //using System;
 //using System.Collections.Generic;
 
@@ -17,7 +15,7 @@
 //    public static implicit operator T(ComparableSome<T> some) => some.Value;
 
 //    #endregion
-//    #region IComparible<T> Implementation
+//    #region IComparable<T> Implementation
 
 //    public int CompareTo(IComparableMaybe<T> other) =>
 //        other is Some <T> s ? CompareTo(s.Value) : -1;

--- a/src/Eithers/IComparableMaybe{T}.cs
+++ b/src/Eithers/IComparableMaybe{T}.cs
@@ -1,5 +1,3 @@
-//#nullable enable
-
 //using System;
 
 //namespace Ainsworth.Eithers;

--- a/src/Eithers/Maybe.cs
+++ b/src/Eithers/Maybe.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace Ainsworth.Eithers;
@@ -21,9 +19,7 @@ public static class Maybe {
     ///   <see cref="Maybe{T}.None"/> singleton is returned. 
     /// </returns>
     public static Maybe<T> From<T>(T? value) where T : struct =>
-        value is T v
-            ? new Some<T>(v)
-            : Maybe<T>.None;
+        value is T v ? new Some<T>(v) : Maybe<T>.None;
 
     /// <summary>
     ///   Create a <see cref="Maybe{T}"/> from a specified value.
@@ -37,9 +33,7 @@ public static class Maybe {
     ///   <see cref="Maybe{T}.None"/> singleton is returned. 
     /// </returns>
     public static Maybe<T> From<T>(T? value) where T : class =>
-        value is not null
-            ? new Some<T>(value)
-            : Maybe<T>.None;
+        value is not null ? new Some<T>(value) : Maybe<T>.None;
 
     /// <summary>
     ///   Create a <see cref="Maybe{T}"/> from a specified, non-<see langword="null"/> value.
@@ -51,7 +45,8 @@ public static class Maybe {
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/>
     ///   is <see langword="null"/>.</exception>
     public static Maybe<T> Some<T>(T value) where T : notnull =>
-        value is null // Null check for callers that don't use code analyzers to catch errors
+        // Null check for callers that don't use code analyzers to catch errors
+        value is null
             ? throw new ArgumentNullException(nameof(value))
             : new Some<T>(value);
 
@@ -66,7 +61,7 @@ public static class Maybe {
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/>
     ///   is <see langword="null"/>.</exception>
-    public static Maybe<T> ToMaybe<T>(this T? value) where T : struct => From<T>(value);
+    public static Maybe<T> ToMaybe<T>(this T? value) where T : struct => From(value);
 
     /// <summary>
     ///   Convert a possibly-<see langword="null"/> value to a <see cref="Maybe{T}"/>.
@@ -79,7 +74,7 @@ public static class Maybe {
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/>
     ///   is <see langword="null"/>.</exception>
-    public static Maybe<T> ToMaybe<T>(this T? value) where T : class => From<T>(value);
+    public static Maybe<T> ToMaybe<T>(this T? value) where T : class => From(value);
 
     /// <summary>
     ///   Convert a non-<see langword="null"/> value to a <see cref="Some{T}"/>.

--- a/src/Eithers/Maybe{T}.cs
+++ b/src/Eithers/Maybe{T}.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -21,6 +19,9 @@ namespace Ainsworth.Eithers;
 ///       .NET Curry: The Maybe Monad (C#)</a></item>
 ///   </list>
 /// </remarks>
+[SuppressMessage(
+    "Design", "CA1067:Override Object.Equals(object) when implementing IEquatable<T>",
+    Justification = "base.GetHasCode() provides correct implementation")]
 public abstract class Maybe<T> : IEquatable<Maybe<T>>, IEquatable<T>, IEnumerable<T>
     where T : notnull {
 
@@ -54,10 +55,7 @@ public abstract class Maybe<T> : IEquatable<Maybe<T>>, IEquatable<T>, IEnumerabl
     [SuppressMessage(
         "Usage", "CA2225:Operator overloads have named alternates",
         Justification = "ToMaybe<T> provided in class Maybe")]
-    public static implicit operator Maybe<T>(T? value) =>
-        value is T v
-            ? new Some<T>(v)
-            : Maybe<T>.None;
+    public static implicit operator Maybe<T>(T? value) => value is T v ? new Some<T>(v) : None;
 
     #endregion
     #region IEquateable<Maybe<T>>, IEquatable<T>, and IEquatable Implementions
@@ -87,24 +85,6 @@ public abstract class Maybe<T> : IEquatable<Maybe<T>>, IEquatable<T>, IEnumerabl
     /// </returns>
     public abstract bool Equals(Maybe<T> other);
 
-    /// <summary>
-    ///   Returns a value indicating whether this instance's wrapped value is equal to
-    ///   the specified object.
-    /// </summary>
-    /// <param name="obj">An object to compare with this instance.</param>
-    /// <returns>
-    ///   <see langword="true"/> if <paramref name="obj"/> is an instance of
-    ///   <see cref="Maybe{T}"/> and <paramref name="obj"/>'s wrapped value equals this
-    ///   instance's wrapped value, or <see langword="true"/> if <paramref name="obj"/> is an
-    ///   instance of <typeparamref name="T"/> and equals this instance's wrapped value;
-    ///   otherwise <see langword="false"/>.
-    /// </returns>
-    public override bool Equals(object? obj) => obj switch {
-        Maybe<T> other => Equals(other),
-        T other => Equals(other),
-        _ => false
-    };
-
     #endregion
     #region IEnumerator<T> Implementation
 
@@ -127,23 +107,6 @@ public abstract class Maybe<T> : IEquatable<Maybe<T>>, IEquatable<T>, IEnumerabl
     ///   instance's zero or one values.
     /// </returns>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-    #endregion
-    #region GetHashCode overrides
-
-    /// <summary>
-    ///   Returns the hash code for this <see cref="Maybe{T}"/>.
-    /// </summary>
-    /// <returns>
-    ///   A 32-bit signed integer hash code.
-    /// </returns>
-    /// <remarks>
-    ///   The hash code for <see cref="Some{T}"/> instances is the wrapped value's hash code.
-    ///   The hash code for <see cref="None{T}"/> instances is computed using
-    ///   <see cref="object.GetHashCode"/> (i.e., the default hash function).
-    /// </remarks>
-    public override int GetHashCode() =>
-        this is Some<T> some ? some.GetHashCode() : base.GetHashCode();
 
     #endregion
 }

--- a/src/Eithers/None{T}.cs
+++ b/src/Eithers/None{T}.cs
@@ -1,10 +1,10 @@
-#nullable enable
-
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Ainsworth.Eithers;
+
+#pragma warning disable CS0659  // Covered by SonarLint S1206
 
 /// <summary>
 ///   The subclass of <see cref="Maybe{T}"/> that represents a Maybe monad
@@ -13,7 +13,10 @@ namespace Ainsworth.Eithers;
 /// <typeparam name="T">The type of the value contained by the  <see cref="Maybe{T}"/>
 ///   superclass.</typeparam>
 [DebuggerDisplay("None")]
-public class None<T> : Maybe<T> 
+[SuppressMessage(
+    "Minor Bug", "S1206:\"Equals(Object)\" and \"GetHashCode()\" should be overridden in pairs",
+    Justification = "base.GetHasCode() provides correct implementation")]
+public class None<T> : Maybe<T>
     where T : notnull {
 
     #region Properties
@@ -42,15 +45,24 @@ public class None<T> : Maybe<T>
     private None() { }
 
     #endregion
-    #region IEquatable<T> Implementation
-
-    // Note: IEquatable implementation inherited from Maybe<T>
+    #region IEquatable<T> and IEquatable<Maybe<T>> Implementations
 
     /// <inheritdoc/>
     public override bool Equals(T other) => false;
 
     /// <inheritdoc/>
-    public override bool Equals(Maybe<T> other) => other == Maybe<T>.None;
+    public override bool Equals(Maybe<T> other) => other == NoneSingleton;
+
+    /// <summary>
+    ///   Returns a value indicating whether this instance's wrapped value is equal to
+    ///   the specified object.
+    /// </summary>
+    /// <param name="obj">An object to compare with this instance.</param>
+    /// <returns>
+    ///   <see langword="true"/> if <paramref name="obj"/> is the <see cref="None{T}"/>
+    ///   singleton; otherwise, <see langword="false"/>.
+    /// </returns>
+    public override bool Equals(object obj) => obj == NoneSingleton;
 
     #endregion
     #region IEnumerable<T> Implementation
@@ -63,8 +75,14 @@ public class None<T> : Maybe<T>
     #endregion
     #region System.Object overrides
 
-    /// <inheritdoc/>
-    public override int GetHashCode() => base.GetHashCode();
+    /// <summary>
+    ///   Returns a string representation of this <see cref="None{T}"/>.
+    /// </summary>
+    /// <returns>
+    ///  A string that represents this <see cref="None{T}"/>.
+    /// </returns>
+    public override string ToString() =>
+        $"{nameof(Maybe<T>)}<{typeof(T).Name}>.{nameof(Maybe<T>.None)}";
 
     #endregion
 }

--- a/src/Eithers/Some{T}.cs
+++ b/src/Eithers/Some{T}.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -55,13 +53,29 @@ public class Some<T> : Maybe<T>
     #endregion
     #region IEquatable<T> and IEquatable<Maybe<T>> Implementations
 
-    // Note: IEquatable implementation inherited from Maybe<T>
-
     /// <inheritdoc/>
     public override bool Equals(T other) => Value.Equals(other);
 
     /// <inheritdoc/>
     public override bool Equals(Maybe<T> other) => other is Some<T> s && Value.Equals(s.Value);
+
+    /// <summary>
+    ///   Returns a value indicating whether this instance's wrapped value is equal to
+    ///   the specified object.
+    /// </summary>
+    /// <param name="obj">An object to compare with this instance.</param>
+    /// <returns>
+    ///   <see langword="true"/> if <paramref name="obj"/> is an instance of
+    ///   <see cref="Maybe{T}"/> and <paramref name="obj"/>'s wrapped value equals this
+    ///   instance's wrapped value, or <see langword="true"/> if <paramref name="obj"/> is an
+    ///   instance of <typeparamref name="T"/> and equals this instance's wrapped value;
+    ///   otherwise <see langword="false"/>.
+    /// </returns>
+    public override bool Equals(object obj) => obj switch {
+        Maybe<T> other => Equals(other),
+        T other => Equals(other),
+        _ => false
+    };
 
     #endregion
     #region IEnumerable<T> Implementation
@@ -74,8 +88,30 @@ public class Some<T> : Maybe<T>
     #endregion
     #region GetHasCode Implementation
 
-    /// <inheritdoc/>
+    /// <summary>
+    ///   Returns the hash code for this <see cref="Maybe{T}"/>.
+    /// </summary>
+    /// <returns>
+    ///   A 32-bit signed integer hash code.
+    /// </returns>
+    /// <remarks>
+    ///   The hash code for <see cref="Some{T}"/> instances is the wrapped value's hash code.
+    ///   The hash code for <see cref="None{T}"/> instances is computed using
+    ///   <see cref="object.GetHashCode"/> (i.e., the default hash function).
+    /// </remarks>
     public override int GetHashCode() => Value.GetHashCode();
+
+    #endregion
+    #region ToString Implementation
+
+    /// <summary>
+    ///   Returns a string representation of this <see cref="Some{T}"/>.
+    /// </summary>
+    /// <returns>
+    ///  A string that represents this <see cref="Some{T}"/>.
+    /// </returns>
+    public override string ToString() =>
+        $"{nameof(Some<T>)}<{typeof(T).Name}>({Value})";
 
     #endregion
 }

--- a/tests/Eithers.Tests/Maybe{T}Tests.cs
+++ b/tests/Eithers.Tests/Maybe{T}Tests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections;
 using System.Reflection;
 
@@ -20,13 +18,13 @@ public class Constructor_Tests {
     [TestMethod]
     public void MaybeT_constructors_are_protected() {
         var type = typeof(Maybe<int>);
-        var ctors = type.GetConstructors(
+        var constructors = type.GetConstructors(
             BindingFlags.Public | BindingFlags.NonPublic |
             BindingFlags.Instance | BindingFlags.Static);
-        foreach (var ctor in ctors) {
+        foreach (var constructor in constructors) {
             Assert.IsFalse(
-                ctor.IsPublic,
-                $"{ctor.DeclaringType!.Name} has at least 1 public constructor");
+                constructor.IsPublic,
+                $"{constructor.DeclaringType!.Name} has at least 1 public constructor");
         }
     }
 }
@@ -34,6 +32,9 @@ public class Constructor_Tests {
 /// <summary>
 ///   Unit test for <see cref="Maybe{T}.Equals(T)"/> tests.
 /// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Blocker Code Smell", "S2187:TestCases should contain tests",
+    Justification = "Tests are in subclasses. This is an audit trail.")]
 [TestClass]
 public class EqualsT_Method_Tests {
     // Maybe<T>.Equals(T) is an abstract method. No tests needed. 
@@ -43,6 +44,9 @@ public class EqualsT_Method_Tests {
 /// <summary>
 ///   Unit test for <see cref="Maybe{T}.Equals(Maybe{T})"/> tests.
 /// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Blocker Code Smell", "S2187:TestCases should contain tests",
+    Justification = "Tests are in subclasses. This is an audit trail.")]
 [TestClass]
 public class EqualsMaybeT_Method_Tests {
     // Maybe<T>.Equals(Maybe<T>>) is an abstract method.
@@ -50,38 +54,38 @@ public class EqualsMaybeT_Method_Tests {
 }
 
 /// <summary>
-///   Unit test for <see cref="Maybe{T}.Equals(object)"/> tests.
+///   Unit test for <see cref="Maybe{T}"/>.Equals(object) tests.
 /// </summary>
 [TestClass]
 public class EqualsObject_Method_Tests {
 
     #region test implementions
 
-    private static void MaybeT_EqualsObject_returns_true_if_same_value<T>(T value)
+    private static void EqualsObject_returns_true_if_same_value<T>(T value)
             where T : notnull {
         Maybe<T> maybe = new Some<T>(value);
         Assert.IsTrue(maybe.Equals((object)value));
     }
 
-    private static void MaybeT_EqualsObject_returns_false_if_different_value<T>(T value, T value2)
+    private static void EqualsObject_returns_false_if_different_value<T>(T value, T value2)
             where T : notnull {
         Maybe<T> maybe = new Some<T>(value);
         Assert.IsFalse(maybe.Equals((object)value2));
     }
 
-    private static void MaybeT_EqualsObject_returns_false_for_None_and_value<T>(T value2)
+    private static void EqualsObject_returns_false_for_None_and_value<T>(T value2)
             where T : notnull =>
         Assert.IsFalse(Maybe<T>.None.Equals((object)value2));
 
-    private static void MaybeT_EqualsObject_returns_false_for_None_and_null<T>()
+    private static void EqualsObject_returns_false_for_None_and_null<T>()
             where T : struct =>
         Assert.IsFalse(Maybe<T>.None.Equals((object)(T?)null!));
 
-    private static void MaybeT_EqualsObject_returns_false_for_None_and_null_reference<T>()
+    private static void EqualsObject_returns_false_for_None_and_null_reference<T>()
             where T : class =>
         Assert.IsFalse(Maybe<T>.None.Equals((object)(T)null!));
 
-    private static void MaybeT_EqualsObject_returns_true_for_None_and_None<T>()
+    private static void EqualsObject_returns_true_for_None_and_None<T>()
             where T : notnull =>
         Assert.IsTrue(Maybe<T>.None.Equals((object)Maybe<T>.None));
 
@@ -93,8 +97,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_EqualsObject_returns_true_for_primitive_types_with_the_same_value() {
-        MaybeT_EqualsObject_returns_true_if_same_value(TestEnum.E11);
-        MaybeT_EqualsObject_returns_true_if_same_value(111);
+        EqualsObject_returns_true_if_same_value(TestEnum.E11);
+        EqualsObject_returns_true_if_same_value(111);
     }
 
     /// <summary>
@@ -103,8 +107,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_EqualsObject_returns_true_for_value_types_with_the_same_value() {
-        MaybeT_EqualsObject_returns_true_if_same_value((111, "111"));
-        MaybeT_EqualsObject_returns_true_if_same_value((decimal)111);
+        EqualsObject_returns_true_if_same_value((111, "111"));
+        EqualsObject_returns_true_if_same_value((decimal)111);
     }
 
     /// <summary>
@@ -117,9 +121,9 @@ public class EqualsObject_Method_Tests {
         // Note: string overrides Equals to compare by value.
         // All other reference types compare by reference.
 
-        MaybeT_EqualsObject_returns_true_if_same_value("111");
-        MaybeT_EqualsObject_returns_true_if_same_value(new int[] { 111 });
-        MaybeT_EqualsObject_returns_true_if_same_value(new TestClass(111, "111"));
+        EqualsObject_returns_true_if_same_value("111");
+        EqualsObject_returns_true_if_same_value(new int[] { 111 });
+        EqualsObject_returns_true_if_same_value(new TestClass(111, "111"));
     }
 
     /// <summary>
@@ -128,8 +132,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_EqualsObject_returns_false_for_primitive_types_with_the_different_value() {
-        MaybeT_EqualsObject_returns_false_if_different_value(TestEnum.E11, TestEnum.E22);
-        MaybeT_EqualsObject_returns_false_if_different_value(111, 222);
+        EqualsObject_returns_false_if_different_value(TestEnum.E11, TestEnum.E22);
+        EqualsObject_returns_false_if_different_value(111, 222);
     }
 
     /// <summary>
@@ -138,8 +142,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_EqualsObject_returns_false_for_value_types_with_the_different_value() {
-        MaybeT_EqualsObject_returns_false_if_different_value((111, "111"), (222, "222"));
-        MaybeT_EqualsObject_returns_false_if_different_value((decimal)111, (decimal)222);
+        EqualsObject_returns_false_if_different_value((111, "111"), (222, "222"));
+        EqualsObject_returns_false_if_different_value<decimal>(111, 222);
     }
 
     /// <summary>
@@ -152,9 +156,9 @@ public class EqualsObject_Method_Tests {
         // Note: string overrides Equals to compare by value.
         // All other reference types compare by reference.
 
-        MaybeT_EqualsObject_returns_false_if_different_value("111", "222");
-        MaybeT_EqualsObject_returns_false_if_different_value(new int[] { 111 }, new int[] { 222 });
-        MaybeT_EqualsObject_returns_false_if_different_value(
+        EqualsObject_returns_false_if_different_value("111", "222");
+        EqualsObject_returns_false_if_different_value(new int[] { 111 }, new int[] { 222 });
+        EqualsObject_returns_false_if_different_value(
             new TestClass(111, "111"), new TestClass(222, "222"));
     }
 
@@ -164,8 +168,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_primitive_type_values() {
-        MaybeT_EqualsObject_returns_false_for_None_and_value(TestEnum.E22);
-        MaybeT_EqualsObject_returns_false_for_None_and_value(222);
+        EqualsObject_returns_false_for_None_and_value(TestEnum.E22);
+        EqualsObject_returns_false_for_None_and_value(222);
     }
 
     /// <summary>
@@ -174,8 +178,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_value_types_values() {
-        MaybeT_EqualsObject_returns_false_for_None_and_value((222, "222"));
-        MaybeT_EqualsObject_returns_false_for_None_and_value((decimal)222);
+        EqualsObject_returns_false_for_None_and_value((222, "222"));
+        EqualsObject_returns_false_for_None_and_value((decimal)222);
     }
 
     /// <summary>
@@ -184,9 +188,9 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_reference_types_values() {
-        MaybeT_EqualsObject_returns_false_for_None_and_value("222");
-        MaybeT_EqualsObject_returns_false_for_None_and_value(new int[] { 222 });
-        MaybeT_EqualsObject_returns_false_for_None_and_value(new TestClass(222, "222"));
+        EqualsObject_returns_false_for_None_and_value("222");
+        EqualsObject_returns_false_for_None_and_value(new int[] { 222 });
+        EqualsObject_returns_false_for_None_and_value(new TestClass(222, "222"));
     }
 
     /// <summary>
@@ -195,8 +199,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_null_primitive_types() {
-        MaybeT_EqualsObject_returns_false_for_None_and_null<TestEnum>();
-        MaybeT_EqualsObject_returns_false_for_None_and_null<int>();
+        EqualsObject_returns_false_for_None_and_null<TestEnum>();
+        EqualsObject_returns_false_for_None_and_null<int>();
     }
 
     /// <summary>
@@ -205,8 +209,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_null_value_types() {
-        MaybeT_EqualsObject_returns_false_for_None_and_null<(int, string)>();
-        MaybeT_EqualsObject_returns_false_for_None_and_null<decimal>();
+        EqualsObject_returns_false_for_None_and_null<(int, string)>();
+        EqualsObject_returns_false_for_None_and_null<decimal>();
     }
 
     /// <summary>
@@ -215,9 +219,9 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_false_for_null_reference_types() {
-        MaybeT_EqualsObject_returns_false_for_None_and_null_reference<string>();
-        MaybeT_EqualsObject_returns_false_for_None_and_null_reference<int[]>();
-        MaybeT_EqualsObject_returns_false_for_None_and_null_reference<TestClass>();
+        EqualsObject_returns_false_for_None_and_null_reference<string>();
+        EqualsObject_returns_false_for_None_and_null_reference<int[]>();
+        EqualsObject_returns_false_for_None_and_null_reference<TestClass>();
     }
 
     /// <summary>
@@ -226,8 +230,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_true_for_primitive_type_None() {
-        MaybeT_EqualsObject_returns_true_for_None_and_None<TestEnum>();
-        MaybeT_EqualsObject_returns_true_for_None_and_None<int>();
+        EqualsObject_returns_true_for_None_and_None<TestEnum>();
+        EqualsObject_returns_true_for_None_and_None<int>();
     }
 
     /// <summary>
@@ -236,8 +240,8 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_true_for_value_type_None() {
-        MaybeT_EqualsObject_returns_true_for_None_and_None<(int, string)>();
-        MaybeT_EqualsObject_returns_true_for_None_and_None<decimal>();
+        EqualsObject_returns_true_for_None_and_None<(int, string)>();
+        EqualsObject_returns_true_for_None_and_None<decimal>();
     }
 
     /// <summary>
@@ -246,9 +250,9 @@ public class EqualsObject_Method_Tests {
     /// </summary>
     [TestMethod]
     public void MaybeT_without_value_EqualsObject_returns_true_for_reference_type_None() {
-        MaybeT_EqualsObject_returns_true_for_None_and_None<string>();
-        MaybeT_EqualsObject_returns_true_for_None_and_None<int[]>();
-        MaybeT_EqualsObject_returns_true_for_None_and_None<TestClass>();
+        EqualsObject_returns_true_for_None_and_None<string>();
+        EqualsObject_returns_true_for_None_and_None<int[]>();
+        EqualsObject_returns_true_for_None_and_None<TestClass>();
     }
 }
 
@@ -314,16 +318,21 @@ public class GetEnumerator_Method_Tests {
 }
 
 /// <summary>
-///   Unit test for <see cref="Maybe{T}.GetHashCode"/> tests.
+///   Unit tests for <see cref="Maybe{T}"/>.GetHashCode().
 /// </summary>
+/// <remarks>
+///   <see cref="Maybe{T}"/> does not override <see cref="object.GetHashCode"/>; however,
+///   <see cref="Some{T}"/> and <see cref="None{T}"/> do.  These test cases show that
+///   the <see cref="object.GetHashCode"/> overrides calculate the expected hash code.
+/// </remarks>
 [TestClass]
 public class GetHashCode_Method_Tests {
 
     #region test implementaions
 
     private static void MaybeT_GetHashCode_returns_correct_value<T>(T value, T value2)
-            where T: notnull {
-        var maybe = Maybe.Some<T>(value);
+            where T : notnull {
+        var maybe = Maybe.Some(value);
         Assert.AreEqual(value.GetHashCode(), maybe.GetHashCode());
         Assert.AreNotEqual(value2.GetHashCode(), maybe.GetHashCode());
     }
@@ -331,7 +340,7 @@ public class GetHashCode_Method_Tests {
     #endregion
 
     /// <summary>
-    ///   The <see cref="Maybe{T}.GetHashCode"/> method returns the correct value
+    ///   The <see cref="object.GetHashCode"/> method returns the correct value
     ///   for primitive type values.
     /// </summary>
     [TestMethod]
@@ -341,23 +350,20 @@ public class GetHashCode_Method_Tests {
     }
 
     /// <summary>
-    ///   The <see cref="Maybe{T}.GetHashCode"/> method returns the correct value
+    ///   The <see cref="object.GetHashCode"/> method returns the correct value
     ///   for value type values.
     /// </summary>
     [TestMethod]
     public void MaybeT_GetHashCode_returns_correct_value_for_value_types() {
         MaybeT_GetHashCode_returns_correct_value((111, "111"), (222, "222"));
-        MaybeT_GetHashCode_returns_correct_value((decimal)111, (decimal)222);
+        MaybeT_GetHashCode_returns_correct_value<decimal>(111, 222);
     }
 
     /// <summary>
-    ///   The <see cref="Maybe{T}.GetHashCode"/> method returns the correct value
+    ///   The <see cref="object.GetHashCode"/> method returns the correct value
     ///   for reference type values.
     /// </summary>
     [TestMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Globalization", "CA1307:Specify StringComparison for clarity",
-        Justification = "StringComparison cannot be used within Maybe<T>")]
     public void MaybeT_GetHashCode_returns_correct_value_for_reference_types() {
         MaybeT_GetHashCode_returns_correct_value("111", "222");
         MaybeT_GetHashCode_returns_correct_value(new int[] { 111 }, new int[] { 222 });
@@ -391,9 +397,9 @@ public class HasValue_Property_Tests {
     [TestMethod]
     public void MaybeT_HasValue_returns_false_for_MaybeT_with_value() {
 
-        var nullIntMaybe = Maybe.From<int>((int?)null);
-        Assert.IsInstanceOfType<Maybe<int>>(nullIntMaybe);
-        Assert.IsFalse(nullIntMaybe.HasValue);
+        var maybe = Maybe.From<int>(null);
+        Assert.IsInstanceOfType<Maybe<int>>(maybe);
+        Assert.IsFalse(maybe.HasValue);
     }
 }
 
@@ -421,23 +427,23 @@ public class MaybeT_Cast_Tests {
         Assert.AreEqual(value, some.Value);
     }
 
-    private static void MaybeT_cast_creates_None_from_null<T>(T? value) where T : struct {
-        var maybe = Maybe.From<T>(value);
-        Assert.IsInstanceOfType<Maybe<T>>(maybe);
-        Assert.IsInstanceOfType<None<T>>(maybe);
-        Assert.AreSame(Maybe<T>.None, maybe);
-    }
-
     private static void MaybeT_cast_creates_Some_from_reference_value<T>(T value) where T : class {
-        var maybe = Maybe.From<T>(value);
+        var maybe = Maybe.From(value);
         Assert.IsInstanceOfType<Maybe<T>>(maybe);
         Assert.IsInstanceOfType<Some<T>>(maybe);
         var some = (maybe as Some<T>)!;
         Assert.AreEqual(value, some.Value);
     }
 
+    private static void MaybeT_cast_creates_None_from_null<T>(T? value) where T : struct {
+        var maybe = Maybe.From(value);
+        Assert.IsInstanceOfType<Maybe<T>>(maybe);
+        Assert.IsInstanceOfType<None<T>>(maybe);
+        Assert.AreSame(Maybe<T>.None, maybe);
+    }
+
     private static void MaybeT_cast_creates_None_from_null<T>(T? value) where T : class {
-        var maybe = Maybe.From<T>(value);
+        var maybe = Maybe.From(value);
         Assert.IsInstanceOfType<Maybe<T>>(maybe);
         Assert.IsInstanceOfType<None<T>>(maybe);
         Assert.AreSame(Maybe<T>.None, maybe);

--- a/tests/Eithers.Tests/None{T}Tests.cs
+++ b/tests/Eithers.Tests/None{T}Tests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Reflection;
 
 using Ainsworth.Eithers;
@@ -19,13 +17,13 @@ public class Constructor_Tests {
     [TestMethod]
     public void NoneT_constructors_are_private() {
         var type = typeof(None<int>);
-        var ctors = type.GetConstructors(
+        var constructors = type.GetConstructors(
             BindingFlags.Public | BindingFlags.NonPublic |
             BindingFlags.Instance | BindingFlags.Static);
-        foreach (var ctor in ctors) {
+        foreach (var constructor in constructors) {
             Assert.IsTrue(
-                ctor.IsPrivate,
-                $"{ctor.DeclaringType!.Name} has at least 1 public constructor");
+                constructor.IsPrivate,
+                $"{constructor.DeclaringType!.Name} has at least 1 public constructor");
         }
     }
 }
@@ -155,38 +153,7 @@ public class GetEnumerator_Method_Tests {
 }
 
 /// <summary>
-///   Unit tests for <see cref="None{T}"/> methods and extention methods.
-/// </summary>
-[TestClass]
-public class GetHashCode_Method_Tests {
-
-    private readonly Maybe<int> none = Maybe<int>.None;
-
-    /// <summary>
-    ///   The <see cref="None{T}.GetHashCode"/> method returns a statistically-unique
-    ///   for each different <see cref="None{T}"/> type.
-    /// </summary>
-    /// <remarks>
-    ///   This requirement is essentially impossible to test.  Confidence is obtained
-    ///   by checking that none of the <see cref="None{T}"/>s used in this test suite
-    ///   generate the same hash.
-    /// </remarks>
-    [TestMethod]
-    public void NoneT_GetHashCode_returns_statistically_unique_value() {
-        var noneHashCode = none.GetHashCode();
-        Assert.AreNotEqual(Maybe<TestEnum>.None.GetHashCode(), Maybe<int>.None.GetHashCode());
-        Assert.AreNotEqual(Maybe<int>.None.GetHashCode(), Maybe<TestEnum>.None.GetHashCode());
-        Assert.AreNotEqual(Maybe<(int, string)>.None.GetHashCode(), Maybe<decimal>.None.GetHashCode());
-        Assert.AreNotEqual(Maybe<decimal>.None.GetHashCode(), Maybe<(int, string)>.None.GetHashCode());
-        Assert.AreNotEqual(noneHashCode, Maybe<string>.None.GetHashCode());
-        Assert.AreNotEqual(noneHashCode, Maybe<int[]>.None.GetHashCode());
-        Assert.AreNotEqual(noneHashCode, Maybe<TestClass>.None.GetHashCode());
-        Assert.AreNotEqual(noneHashCode, Maybe.From<int>(111).GetHashCode());
-    }
-}
-
-/// <summary>
-///   Unit tests for <see cref="Some{T}"/> methods and extention methods.
+///   Unit tests for <see cref="Some{T}.HasValue"/> property.
 /// </summary>
 [TestClass]
 public class HasValue_Property_Tests {
@@ -199,10 +166,31 @@ public class HasValue_Property_Tests {
     public void NoneT_HasValue_returns_false_for_primitive_types() {
         Assert.IsFalse(Maybe<int>.None.HasValue);
         Assert.IsFalse(Maybe<TestEnum>.None.HasValue);
-        Assert.IsFalse(Maybe<TestStruct>.None.HasValue);
         Assert.IsFalse(Maybe<(int, string)>.None.HasValue);
+        Assert.IsFalse(Maybe<decimal>.None.HasValue);
         Assert.IsFalse(Maybe<string>.None.HasValue);
         Assert.IsFalse(Maybe<int[]>.None.HasValue);
         Assert.IsFalse(Maybe<TestClass>.None.HasValue);
+    }
+}
+
+/// <summary>
+///   Unit tests for the <see cref="None{T}.ToString"/> method.
+/// </summary>
+[TestClass]
+public class ToString_Tests {
+
+    /// <summary>
+    ///   The <see cref="None{T}.ToString"/> method returns the expected represention.
+    /// </summary>
+    [TestMethod]
+    public void NoneT_ToString_creates_expected_representation() {
+        Assert.AreEqual("Maybe<TestEnum>.None", Maybe<TestEnum>.None.ToString());
+        Assert.AreEqual("Maybe<Int32>.None", Maybe<int>.None.ToString());
+        Assert.AreEqual("Maybe<ValueTuple`2>.None", Maybe<(int, string)>.None.ToString());
+        Assert.AreEqual("Maybe<Decimal>.None", Maybe<decimal>.None.ToString());
+        Assert.AreEqual("Maybe<String>.None", Maybe<string>.None.ToString());
+        Assert.AreEqual("Maybe<Int32[]>.None", Maybe<int[]>.None.ToString());
+        Assert.AreEqual("Maybe<TestClass>.None", Maybe<TestClass>.None.ToString());
     }
 }

--- a/tests/Eithers.Tests/Properties/Usings.cs
+++ b/tests/Eithers.Tests/Properties/Usings.cs
@@ -1,1 +1,3 @@
+// Usings that apply to the entire C# project
+
 global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/tests/Eithers.Tests/S4144.cs
+++ b/tests/Eithers.Tests/S4144.cs
@@ -1,0 +1,33 @@
+﻿//using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+//namespace S4144Demo;
+
+//public abstract class Wrap<T> where T : notnull { }
+
+//public class WrapV<T> : Wrap<T> where T : notnull {
+//    public T Value { get; init; }
+//    internal WrapV(T value) => Value = value;
+//}
+
+//public class WrapN<T> : Wrap<T> where T : notnull {
+//    private WrapN() { }
+//    internal static WrapN<T> Singleton = new();
+//}
+
+//public static class Wrap {
+//    public static Wrap<T> From<T>(T? value) where T : struct =>
+//        value is T v ? new WrapV<T>(v) : WrapN<T>.Singleton;
+//    public static Wrap<T> From<T>(T? value) where T : class =>
+//        value is not null ? new WrapV<T>(value) : WrapN<T>.Singleton;
+//}
+
+//public static class S4144 {
+//    public static void TestValueType<T>(T? value) where T : struct {
+//        var maybe = Wrap.From(value);
+//        Assert.AreEqual(value, (maybe as WrapV<T>)!.Value);
+//    }
+//    public static void TestReferenceType<T>(T? value) where T : class {
+//        var maybe = Wrap.From(value);
+//        Assert.AreEqual(value, (maybe as WrapV<T>)!.Value);
+//    }
+//}

--- a/tests/Eithers.Tests/Some{T}Tests.cs
+++ b/tests/Eithers.Tests/Some{T}Tests.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Reflection;
 
 using Ainsworth.Eithers;
@@ -16,7 +14,7 @@ public class Cast_Tests {
 
     #region test implementations
 
-    private static void SomeT_case_creates_Some_from_value<T>(T value) where T: notnull {
+    private static void SomeT_case_creates_Some_from_value<T>(T value) where T : notnull {
 
         // explicit cast
         var some = (Some<T>)value;
@@ -73,7 +71,7 @@ public class Constructor_Tests {
 
     #region test implementations
 
-    private static void SomeT_constructor_creates_SomeT<T>(T value) where T: notnull {
+    private static void SomeT_constructor_creates_SomeT<T>(T value) where T : notnull {
         var some = new Some<T>(value);
         Assert.IsInstanceOfType<Some<T>>(some);
         Assert.IsInstanceOfType<Maybe<T>>(some);
@@ -91,14 +89,14 @@ public class Constructor_Tests {
     [TestMethod]
     public void SomeT_constructors_are_protected_or_internal() {
         var type = typeof(Some<int>);
-        var ctors = type.GetConstructors(
+        var constructors = type.GetConstructors(
             BindingFlags.Public | BindingFlags.NonPublic |
             BindingFlags.Instance | BindingFlags.Static);
-        foreach (var ctor in ctors) {
+        foreach (var constructor in constructors) {
             // It
             Assert.IsFalse(
-                ctor.IsPublic,
-                $"{ctor.DeclaringType!.Name} has at least 1 public constructor");
+                constructor.IsPublic,
+                $"{constructor.DeclaringType!.Name} has at least 1 public constructor");
         }
     }
 
@@ -219,7 +217,7 @@ public class EqualsT_Method_Tests {
     [TestMethod]
     public void SomeT_EqualsT_returns_false_for_value_types_with_the_different_value() {
         EqualsT_returns_true_for_different_value((111, "111"), (222, "222"));
-        EqualsT_returns_true_for_different_value((decimal)111, (decimal)222);
+        EqualsT_returns_true_for_different_value<decimal>(111, 222);
     }
 
     /// <summary>
@@ -320,7 +318,7 @@ public class Equals_MaybeT_Method_Tests {
     [TestMethod]
     public void SomeT_EqualsMaybeT_returns_false_for_value_type_with_the_different_value() {
         Equals_MaybeT_returns_false_for_different_value((111, "111"), (222, "222"));
-        Equals_MaybeT_returns_false_for_different_value((decimal)111, (decimal)222);
+        Equals_MaybeT_returns_false_for_different_value<decimal>(111, 222);
     }
 
     /// <summary>
@@ -383,7 +381,7 @@ public class GetEnumerator_Method_Tests {
 
     #region test implementaions
 
-    private static void GetEnumerator_returns_correct_enumerator<T>(T value) where T: notnull {
+    private static void GetEnumerator_returns_correct_enumerator<T>(T value) where T : notnull {
         var some = new Some<T>(value);
         var enumerator = some.GetEnumerator();
         Assert.IsInstanceOfType<IEnumerator<T>>(enumerator);
@@ -427,7 +425,7 @@ public class GetEnumerator_Method_Tests {
 }
 
 /// <summary>
-///   Unit tests for <see cref="Some{T}"/> methods and extention methods.
+///   Unit tests for <see cref="Some{T}"/> methods and extension methods.
 /// </summary>
 [TestClass]
 public class GetHashCode_Method_Tests {
@@ -436,7 +434,7 @@ public class GetHashCode_Method_Tests {
 
     private static void GetHashCode_returns_hash_value_derived_from_wrapped_value<T>(
             T value, T value2)
-            where T: notnull {
+            where T : notnull {
         var maybe = new Some<T>(value);
         Assert.AreEqual(value.GetHashCode(), maybe.GetHashCode());
         Assert.AreNotEqual(value2.GetHashCode(), maybe.GetHashCode());
@@ -445,39 +443,30 @@ public class GetHashCode_Method_Tests {
     #endregion
 
     /// <summary>
-    ///   The <see cref="None{T}.GetHashCode"/> method returns a hash code computed
-    ///   from the wrapped value for primtive type.
+    ///   The <see cref="Some{T}.GetHashCode"/> method returns a hash code computed
+    ///   from the wrapped value for primitive type.
     /// </summary>
     [TestMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Globalization", "CA1307:Specify StringComparison for clarity",
-        Justification = "StringComparison cannot be used within Maybe<T>")]
     public void SomeT_GetHashCode_returns_hash_value_derived_from_wrapped_value_for_primitive_types() {
         GetHashCode_returns_hash_value_derived_from_wrapped_value(111, 222);
         GetHashCode_returns_hash_value_derived_from_wrapped_value(TestEnum.E11, TestEnum.E22);
     }
 
     /// <summary>
-    ///   The <see cref="None{T}.GetHashCode"/> method returns a hash code computed
+    ///   The <see cref="Some{T}.GetHashCode"/> method returns a hash code computed
     ///   from the wrapped value for value types.
     /// </summary>
     [TestMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Globalization", "CA1307:Specify StringComparison for clarity",
-        Justification = "StringComparison cannot be used within Maybe<T>")]
     public void SomeT_GetHashCode_returns_hash_value_derived_from_wrapped_value_for_value_types() {
         GetHashCode_returns_hash_value_derived_from_wrapped_value((111, "111"), (222, "222"));
-        GetHashCode_returns_hash_value_derived_from_wrapped_value((decimal)111, (decimal)222);
+        GetHashCode_returns_hash_value_derived_from_wrapped_value<decimal>(111, 222);
     }
 
     /// <summary>
-    ///   The <see cref="None{T}.GetHashCode"/> method returns a hash code computed
+    ///   The <see cref="Some{T}.GetHashCode"/> method returns a hash code computed
     ///   from the wrapped value for reference types.
     /// </summary>
     [TestMethod]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Globalization", "CA1307:Specify StringComparison for clarity",
-        Justification = "StringComparison cannot be used within Maybe<T>")]
     public void SomeT_GetHashCode_returns_hash_value_derived_from_wrapped_value_for_reference_types() {
         GetHashCode_returns_hash_value_derived_from_wrapped_value("111", "222");
         GetHashCode_returns_hash_value_derived_from_wrapped_value(
@@ -495,7 +484,7 @@ public class HasValue_Property_Tests {
 
     #region test implementations
 
-    private static void HasValue_returns_true<T>(T value) where T: notnull {
+    private static void HasValue_returns_true<T>(T value) where T : notnull {
         var some = new Some<T>(value);
         Assert.IsTrue(some.HasValue);
     }
@@ -535,7 +524,7 @@ public class HasValue_Property_Tests {
 }
 
 /// <summary>
-///   Unit tests for <see cref="Some{T}"/> methods and extention methods.
+///   Unit tests for <see cref="Some{T}"/> methods and extension methods.
 /// </summary>
 [TestClass]
 public class Value_Property_Tests {
@@ -578,5 +567,28 @@ public class Value_Property_Tests {
         Value_is_initialized_to_correct_value("111");
         Value_is_initialized_to_correct_value(new int[] { 111 });
         Value_is_initialized_to_correct_value(new TestClass(111, "111"));
+    }
+}
+
+/// <summary>
+///   Unit tests for the <see cref="Some{T}.ToString"/> method.
+/// </summary>
+[TestClass]
+public class ToString_Tests {
+
+    /// <summary>
+    ///   The <see cref="Some{T}.ToString"/> method returns the expected represention.
+    /// </summary>
+    [TestMethod]
+    public void NoneT_ToString_creates_expected_representation() {
+        Assert.AreEqual("Some<TestEnum>(E11)", Maybe.Some(TestEnum.E11).ToString());
+        Assert.AreEqual("Some<Int32>(111)", Maybe.Some(111).ToString());
+        Assert.AreEqual("Some<ValueTuple`2>((111, 111))", Maybe.Some((111, "111")).ToString());
+        Assert.AreEqual("Some<Decimal>(111)", Maybe.Some((decimal)111).ToString());
+        Assert.AreEqual("Some<String>(111)", Maybe.Some("111").ToString());
+        Assert.AreEqual("Some<Int32[]>(System.Int32[])", Maybe.Some(new int[] { 111 }).ToString());
+        Assert.AreEqual(
+            "Some<TestClass>(TestClass { I = 111, S = 111 })",
+            Maybe.Some(new TestClass(111, "111")).ToString());
     }
 }

--- a/tests/Eithers.Tests/TestData.cs
+++ b/tests/Eithers.Tests/TestData.cs
@@ -1,12 +1,10 @@
-#nullable enable
-
-using System.Diagnostics;
-
 namespace Ainsworth.Eithers.Tests;
 
 internal static class TestData {
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Minor Code Smell", "S2344:Enumeration type names should not have \"Flags\" or \"Enum\" suffixes",
+        Justification = "The 'Enum' suffix makes sense in this testing context.")]
     internal enum TestEnum { E11, E22 }
-    internal record struct TestStruct(int I, string S);
     internal sealed record class TestClass(int I, string S);
 }


### PR DESCRIPTION
- Remove redundant function overrides (particularly object.GetHashCode()) and suppress resulting false positive SonarLint diagnostics.
- Switch from `#nullable enable` to `<Nullable>enable</Nullable>` in csproj file.
- Simplify types (e.g., remove unecessary generic type arguments).
- Fix mispellings.
- Minor formatting improvements.

resolves #15 
