### PR TITLE
Eliminate ‘init’ hack (#27)

### DIFF
--- a/src/Eithers/CSharpShims/System_Runtime_CompilerServices.cs
+++ b/src/Eithers/CSharpShims/System_Runtime_CompilerServices.cs
@@ -1,7 +1,0 @@
-namespace System.Runtime.CompilerServices;
-
-/// <summary>
-/// An ugly hack to allow C# 9 features in C# Standard.
-/// </summary>
-#pragma warning disable S2094 // Classes should not be empty
-internal static class IsExternalInit { }

--- a/src/Eithers/Some{T}.cs
+++ b/src/Eithers/Some{T}.cs
@@ -24,7 +24,7 @@ public sealed class Some<T> : Maybe<T> where T : notnull {
     /// <value>
     ///   The value wrapped by this <see cref="Maybe{T}"/> instance.
     /// </value>
-    public T Value { get; private init; }
+    public T Value { get; private set; }
 
     #endregion
     #region Constructors, Casts, and Conversions


### PR DESCRIPTION
- Remove `IsExternalInit` class
- Change all property `init` to `private get`

resolves #27 